### PR TITLE
Add new command for reindex into a new index

### DIFF
--- a/nexus/task_managers/management/commands/reindex_content_bases.py
+++ b/nexus/task_managers/management/commands/reindex_content_bases.py
@@ -1,0 +1,25 @@
+import logging
+from django.core.management.base import BaseCommand
+from nexus.intelligences.models import ContentBaseFile, ContentBaseLink, ContentBaseText
+from nexus.task_managers.tasks import upload_file, send_link, upload_text_file
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = 'Command to reindex all the content bases into sentenx'
+
+    def handle(self, *args, **options):
+        # Process ContentBaseFile objects
+        for cbf in ContentBaseFile.objects.filter(is_active=True):
+            self.stdout.write(self.style.WARNING(f'Processing ContentBaseFile: {cbf.uuid}'))
+            upload_file.delay(
+                file=cbf.file,
+                content_base_uuid=str(cbf.content_base.uuid),
+                extension_file=cbf.extension_file,
+                user_email=cbf.created_by.email,
+                content_base_file_uuid=str(cbf.uuid)
+            )
+
+        self.stdout.write(self.style.SUCCESS('Finished processing ContentBaseFile objects.'))
+
+        self.stdout.write(self.style.SUCCESS('Successfully processed all active content base objects'))

--- a/nexus/task_managers/management/commands/reindex_content_bases.py
+++ b/nexus/task_managers/management/commands/reindex_content_bases.py
@@ -1,9 +1,7 @@
-import logging
 from django.core.management.base import BaseCommand
 from nexus.intelligences.models import ContentBaseFile, ContentBaseLink, ContentBaseText
-from nexus.task_managers.tasks import upload_file, send_link, upload_text_file
-
-logger = logging.getLogger(__name__)
+from nexus.usecases.task_managers.celery_task_manager import CeleryTaskManagerUseCase
+from nexus.task_managers.tasks import add_file
 
 class Command(BaseCommand):
     help = 'Command to reindex all the content bases into sentenx'
@@ -11,15 +9,28 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Process ContentBaseFile objects
         for cbf in ContentBaseFile.objects.filter(is_active=True):
-            self.stdout.write(self.style.WARNING(f'Processing ContentBaseFile: {cbf.uuid}'))
-            upload_file.delay(
-                file=cbf.file,
-                content_base_uuid=str(cbf.content_base.uuid),
-                extension_file=cbf.extension_file,
-                user_email=cbf.created_by.email,
-                content_base_file_uuid=str(cbf.uuid)
-            )
+            self.stdout.write(self.style.WARNING(f'Queuing ContentBaseFile: {cbf.uuid}'))
 
-        self.stdout.write(self.style.SUCCESS('Finished processing ContentBaseFile objects.'))
+            task_manager = CeleryTaskManagerUseCase().create_celery_task_manager(content_base_file=cbf)
+            add_file.apply_async(args=[str(task_manager.uuid), "file", "pdfminer"])
 
+        self.stdout.write(self.style.SUCCESS('Finished queuing ContentBaseFile objects.'))
+
+        # Process ContentBaseLink objects
+        for cbl in ContentBaseLink.objects.filter(is_active=True):
+            self.stdout.write(self.style.WARNING(f'Queuing ContentBaseLink UUID: {cbl.uuid}'))
+
+            task_manager = CeleryTaskManagerUseCase().create_celery_link_manager(content_base_link=cbl)
+            add_file.apply_async(args=[str(task_manager.uuid), "link"])
+
+        self.stdout.write(self.style.SUCCESS('Finished queuing ContentBaseLink objects.'))
+
+        # Process ContentBaseText objects
+        for cbt in ContentBaseText.objects.filter(is_active=True):
+            self.stdout.write(self.style.WARNING(f'Processing ContentBaseText UUID: {cbt.uuid}'))
+
+            task_manager = CeleryTaskManagerUseCase().create_celery_text_file_manager(content_base_text=cbt)
+            add_file.apply_async(args=[str(task_manager.uuid), "text"])
+
+        self.stdout.write(self.style.SUCCESS('Finished processing ContentBaseText objects.'))
         self.stdout.write(self.style.SUCCESS('Successfully processed all active content base objects'))

--- a/nexus/task_managers/tasks.py
+++ b/nexus/task_managers/tasks.py
@@ -64,28 +64,25 @@ def upload_file(
     content_base_file_uuid: str,
     load_type: str = None
 ):
-    if file != None:
-        file = pickle.loads(file)
-        file_database_response = s3FileDatabase().add_file(file)
+    file = pickle.loads(file)
+    file_database_response = s3FileDatabase().add_file(file)
 
-        if file_database_response.status != 0:
-            return {
-                "task_status": ContentBaseFileTaskManager.STATUS_FAIL,
-                "error": file_database_response.err
-            }
+    if file_database_response.status != 0:
+        return {
+            "task_status": ContentBaseFileTaskManager.STATUS_FAIL,
+            "error": file_database_response.err
+        }
 
-        content_base_file_dto = UpdateContentBaseFileDTO(
-            file_url=file_database_response.file_url,
-            file_name=file_database_response.file_name
-        )
+    content_base_file_dto = UpdateContentBaseFileDTO(
+        file_url=file_database_response.file_url,
+        file_name=file_database_response.file_name
+    )
 
-        content_base_file = UpdateContentBaseFileUseCase().update_content_base_file(
-            content_base_file_uuid=content_base_file_uuid,
-            user_email=user_email,
-            update_content_base_file_dto=content_base_file_dto
-        )
-    else:
-        content_base_file = get_by_content_base_file_uuid(content_base_file_uuid)
+    content_base_file = UpdateContentBaseFileUseCase().update_content_base_file(
+        content_base_file_uuid=content_base_file_uuid,
+        user_email=user_email,
+        update_content_base_file_dto=content_base_file_dto
+    )
 
     task_manager = CeleryTaskManagerUseCase().create_celery_task_manager(content_base_file=content_base_file)
 

--- a/nexus/task_managers/tasks.py
+++ b/nexus/task_managers/tasks.py
@@ -17,7 +17,7 @@ from nexus.intelligences.models import (
 from nexus.usecases.task_managers.celery_task_manager import CeleryTaskManagerUseCase
 from nexus.usecases.intelligences.intelligences_dto import UpdateContentBaseFileDTO
 from nexus.usecases.intelligences.update import UpdateContentBaseFileUseCase
-from nexus.usecases.intelligences.get_by_uuid import get_by_contentbase_uuid, get_by_content_base_file_uuid
+from nexus.usecases.intelligences.get_by_uuid import get_by_contentbase_uuid
 from typing import Dict
 
 from nexus.trulens import wenigpt_evaluation, tru_recorder


### PR DESCRIPTION
This command was created to reindex all active files, links, and text into a new index. The decision to have a new index is that, is too dangerous to keep the previous index active, once the embedding model was changed and it would lead to confused results when searching.