### PR TITLE
Fix: Project Auth not created

### DIFF
--- a/nexus/projects/permissions.py
+++ b/nexus/projects/permissions.py
@@ -4,19 +4,26 @@ from .exceptions import ProjectAuthorizationDenied
 from .models import Project, ProjectAuth, ProjectAuthorizationRole
 
 from nexus.users.models import User
+from nexus.orgs.models import OrgAuth, Role
 
 
 def get_user_auth(
     user: User,
     project: Project
 ):
-    try:
-        auth = ProjectAuth.objects.get(user=user, project=project)
-    except ProjectAuth.DoesNotExist:
-        raise ProjectAuthorizationDenied(
-            'You do not have permission to perform this action.'
+    auth = ProjectAuth.objects.filter(user=user, project=project).first()
+    if auth:
+        return auth
+
+    org_auth = OrgAuth.objects.filter(user=user, org=project.org).first()
+    if org_auth and org_auth.role == Role.ADMIN.value:
+        return ProjectAuth.objects.create(
+            user=user,
+            project=project,
+            role=ProjectAuthorizationRole.MODERATOR.value
         )
-    return auth
+
+    raise ProjectAuth.DoesNotExist("User does not have authorization to access this project.")
 
 
 def is_admin(

--- a/nexus/projects/permissions.py
+++ b/nexus/projects/permissions.py
@@ -62,7 +62,7 @@ def _has_project_general_permission(
             'You do not have permission to perform this action.'
         )
     except ProjectAuth.DoesNotExist:
-        raise ProjectAuthorizationDenied(
+        raise ProjectAuth.DoesNotExist(
             'You do not have permission to perform this action.'
         )
 

--- a/nexus/usecases/intelligences/tests/test_retrieve_intelligence.py
+++ b/nexus/usecases/intelligences/tests/test_retrieve_intelligence.py
@@ -26,7 +26,7 @@ from nexus.usecases.intelligences.retrieve import RetrieveContentBaseFileUseCase
 from nexus.usecases.users.tests.user_factory import UserFactory
 from nexus.usecases.intelligences.exceptions import IntelligencePermissionDenied
 
-from nexus.projects.exceptions import ProjectAuthorizationDenied
+from nexus.projects.models import ProjectAuth
 
 
 class TestRetrieveIntelligenceUseCase(TestCase):
@@ -97,7 +97,7 @@ class TestRetrieveContentBaseUseCase(TestCase):
         self.assertIsInstance(contentbase_retrieve, ContentBase)
 
     def test_get_default_by_project_fail(self):
-        with self.assertRaises(ProjectAuthorizationDenied):
+        with self.assertRaises(ProjectAuth.DoesNotExist):
             self.usecase.get_default_by_project(
                 project_uuid=self.project.uuid,
                 user_email=self.user.email

--- a/nexus/usecases/projects/tests/test_get_by_uuid.py
+++ b/nexus/usecases/projects/tests/test_get_by_uuid.py
@@ -8,9 +8,9 @@ from nexus.usecases.users.tests.user_factory import UserFactory
 
 from nexus.usecases.projects.retrieve import get_project
 from nexus.projects.exceptions import (
-    ProjectAuthorizationDenied,
     ProjectDoesNotExist,
 )
+from nexus.projects.models import ProjectAuth
 
 from nexus.usecases.projects.get_by_uuid import get_project_by_uuid
 
@@ -41,7 +41,7 @@ class GetByProjectUuidTestCase(TestCase):
         self.assertEqual(self.project, project)
 
     def test_fail_get_project(self):
-        with self.assertRaises(ProjectAuthorizationDenied):
+        with self.assertRaises(ProjectAuth.DoesNotExist):
             get_project(str(self.project.uuid), self.user.email)
 
     def test_get_by_uuid_non_existent_project(self):


### PR DESCRIPTION
Add a second layer of validation to project auth, in the case it doesn't exist, check if the Organization authorization exist instead. 