### PR TITLE
Feature: Custom middleware changes

### DIFF
--- a/nexus/logs/middleware.py
+++ b/nexus/logs/middleware.py
@@ -10,7 +10,8 @@ class PrometheusAuthenticationMiddleware:
     def __call__(self, request):
         if request.path.startswith('/api/prometheus/'):
             auth_token = request.headers.get('Authorization')
-            expected_token = os.environ.get('PROMETHEUS_AUTH_TOKEN')
+            variable_token = os.environ.get('PROMETHEUS_AUTH_TOKEN')
+            expected_token = f'Bearer {variable_token}'
 
             if not auth_token or auth_token != expected_token:
                 return HttpResponseForbidden('Acesso negado')

--- a/nexus/middleware.py
+++ b/nexus/middleware.py
@@ -1,0 +1,13 @@
+from django.utils.deprecation import MiddlewareMixin
+
+
+class SwaggerXFrameOptionsMiddleware(MiddlewareMixin):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def process_response(self, request, response):
+        if request.path == '/':
+            response['X-Frame-Options'] = 'SAMEORIGIN'
+
+        response = self.get_response(request)
+        return response


### PR DESCRIPTION
Change current prometheus middleware to use Bearer token instead of just token. Add a new middleware to X-Frame-Options sameorigin for swagger api documentation