### PR TITLE
Add AgentTracesView and serializers for AgentMessage history

### DIFF
--- a/nexus/agents/api/routers.py
+++ b/nexus/agents/api/routers.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from nexus.agents.api.views import (
     ActiveAgentsViewSet,
+    AgentTracesView,
     AgentsView,
     PushAgents,
     TeamView,
@@ -14,6 +15,7 @@ urlpatterns = [
     path('agents/teams/<project_uuid>', TeamView.as_view(), name="teams"),
     path('agents/my-agents/<project_uuid>', AgentsView.as_view(), name="my-agents"),
     path('agents/official/<project_uuid>', OfficialAgentsView.as_view(), name="official-agents"),
+    path('agents/traces/', AgentTracesView.as_view(), name="traces"),
     path('project/<project_uuid>/assign/<str:agent_uuid>', ActiveAgentsViewSet.as_view(), name="assign-agents"),
     path('project/<project_uuid>/credentials', ProjectCredentialsView.as_view(), name="project-credentials"),
     path('project/<project_uuid>/credentials/<str:agent_uuid>', ProjectCredentialsView.as_view(), name="project-credentials-update"),

--- a/nexus/agents/api/serializers.py
+++ b/nexus/agents/api/serializers.py
@@ -7,6 +7,7 @@ from nexus.agents.models import (
     ActiveAgent,
     AgentSkills,
     Credential,
+    AgentMessage,
 )
 
 class ActiveAgentSerializer(serializers.ModelSerializer):
@@ -149,3 +150,82 @@ class ProjectCredentialsListSerializer(serializers.ModelSerializer):
             return obj.value
         return obj.decrypted_value
 
+
+class AgentMessageHistorySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = AgentMessage
+        fields = [
+            'id',
+            'created_at',
+            'message_text',
+            'tag',
+            'classification',
+        ]
+    
+    message_text = serializers.SerializerMethodField()
+    tag = serializers.SerializerMethodField()
+    classification = serializers.SerializerMethodField()
+
+    def get_message_text(self, obj):
+        return obj.user_text
+
+    def get_tag(self, obj):
+        return "S"
+    
+    def get_classification(self, obj):
+        return "other"
+
+
+class AgentMessageDetailSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentMessage
+        fields = [
+            "id",
+            "uuid",
+            "text",
+            "status",
+            "llm_response",
+            "groundedness",
+            "contact_urn",
+            "actions_started",
+            "actions_uuid",
+            "actions_type",
+            "is_approved",
+        ]
+
+    text = serializers.SerializerMethodField()
+    llm_response = serializers.SerializerMethodField()
+    groundedness = serializers.SerializerMethodField()
+    actions_started = serializers.SerializerMethodField()
+    actions_type = serializers.SerializerMethodField()
+    actions_uuid = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    is_approved = serializers.SerializerMethodField()
+
+    def get_text(self, obj):
+        return obj.user_text
+        return obj.response_status
+
+    def get_llm_response(self, obj):
+        return obj.agent_response
+
+    def get_groundedness(self, obj) -> str | None:
+        return None
+
+    def get_actions_started(self, obj):
+        return False
+
+    def get_actions_type(self, obj):
+        return "other"
+
+    def get_actions_uuid(self, obj):
+        return None
+
+    def get_status(self, obj):
+        return "S"
+
+    def get_is_approved(self, obj):
+        return True
+
+# class AgentTraceSerializer(serializers.ModelSerializer):

--- a/nexus/agents/api/serializers.py
+++ b/nexus/agents/api/serializers.py
@@ -227,5 +227,3 @@ class AgentMessageDetailSerializer(serializers.ModelSerializer):
 
     def get_is_approved(self, obj):
         return True
-
-# class AgentTraceSerializer(serializers.ModelSerializer):

--- a/nexus/agents/api/views.py
+++ b/nexus/agents/api/views.py
@@ -27,6 +27,7 @@ from nexus.usecases.agents import (
 )
 from nexus.usecases.agents.exceptions import SkillFileTooLarge
 from nexus.projects.api.permissions import ProjectPermission
+from nexus.projects.permissions import has_project_permission
 
 
 class PushAgents(APIView):
@@ -596,3 +597,27 @@ class ProjectCredentialsView(APIView):
             "message": "Credentials created successfully",
             "created_credentials": created_credentials
         })
+
+
+class AgentTracesView(
+    APIView
+):
+    def get(self, request):
+        user = self.request.user
+
+        project_uuid = request.query_params.get('project_uuid')
+        log_id = request.query_params.get('log_id')
+
+        print(project_uuid, log_id)
+
+        has_project_permission(user, project_uuid, 'GET')
+
+        if not log_id:
+            return Response({"error": "log_id is required"}, status=400)
+            
+        usecase = AgentUsecase()
+        try:
+            trace_data = usecase.get_traces(project_uuid, log_id)
+            return Response(trace_data)
+        except Exception as e:
+            return Response({"error": str(e)}, status=500)

--- a/nexus/logs/api/views.py
+++ b/nexus/logs/api/views.py
@@ -164,7 +164,7 @@ class MessageHistoryViewset(
             project.team
 
             if text_param:
-                params["user__text__icontains"] = text_param
+                params["user_text__icontains"] = text_param
             
             print(params)
             print(AgentMessage.objects.all())

--- a/nexus/logs/api/views.py
+++ b/nexus/logs/api/views.py
@@ -165,9 +165,6 @@ class MessageHistoryViewset(
 
             if text_param:
                 params["user_text__icontains"] = text_param
-            
-            print(params)
-            print(AgentMessage.objects.all())
 
             logs = AgentMessage.objects.filter(
                 **params

--- a/nexus/task_managers/file_database/bedrock.py
+++ b/nexus/task_managers/file_database/bedrock.py
@@ -1011,3 +1011,10 @@ class BedrockFileDatabase(FileDataBase):
     def upload_traces(self, data, key):
         bytes_stream = BytesIO(data.encode('utf-8'))
         self.s3_client.upload_fileobj(bytes_stream, self.bucket_name, key)
+
+    def get_trace_file(self, key):
+        try:
+            response = self.s3_client.get_object(Bucket=self.bucket_name, Key=key)
+            return response['Body'].read().decode('utf-8')
+        except self.s3_client.exceptions.NoSuchKey:
+            return []

--- a/nexus/usecases/agents/agents.py
+++ b/nexus/usecases/agents/agents.py
@@ -1,4 +1,5 @@
 import uuid
+import json
 
 from typing import Dict, List, Tuple
 from dataclasses import dataclass, field
@@ -27,6 +28,7 @@ from nexus.usecases.agents.exceptions import (
     SkillNameTooLong,
     AgentAttributeNotAllowed
 )
+from nexus.agents.models import AgentMessage
 
 
 @dataclass
@@ -975,3 +977,39 @@ class AgentUsecase:
         team.metadata["is_single_agent"] = not multi_agent
         team.save(update_fields=["metadata"])
         return
+
+    def get_agent_message_by_id(self, agent_message_id: str):
+        return AgentMessage.objects.get(id=agent_message_id)
+
+    def list_last_logs(
+        self,
+        log_id: int,
+        message_count: int = 5,
+    ):
+        log = AgentMessage.objects.get(id=log_id)
+        project = log.project
+        source = log.source
+        contact_urn = log.contact_urn
+        created_at = log.created_at
+
+        logs = AgentMessage.objects.filter(
+            project=project,
+            source=source,
+            contact_urn=contact_urn,
+            session_id=log.session_id,
+            created_at__lt=created_at
+        ).order_by("-created_at")[:message_count]
+
+        logs = list(logs)[::-1]
+
+        return logs
+
+    def get_traces(self, project_uuid: str, log_id: str):
+        log = AgentMessage.objects.get(id=log_id)
+        key = f"traces/{project_uuid}/{log.uuid}.jsonl"
+        traces_data = BedrockFileDatabase().get_trace_file(key)
+        if traces_data:
+            traces = [json.loads(line) for line in traces_data.splitlines() if line]
+            return traces
+        return []
+        


### PR DESCRIPTION
- Introduced AgentTracesView to handle trace retrieval based on project UUID and log ID.
- Added AgentMessageHistorySerializer and AgentMessageDetailSerializer for serializing AgentMessage data.
- Updated the AgentUsecase to include methods for fetching agent messages and traces.
- Enhanced existing views to utilize the new serializers for improved message handling.