### PR TITLE
Fix: Human support null

### DIFF
--- a/nexus/intelligences/api/serializers.py
+++ b/nexus/intelligences/api/serializers.py
@@ -13,6 +13,7 @@ from nexus.intelligences.models import (
     ContentBaseAgent,
 )
 from nexus.agents.models import Team
+from nexus.projects.models import Project
 from nexus.task_managers.models import (
     ContentBaseFileTaskManager,
     ContentBaseLinkTaskManager,
@@ -164,7 +165,11 @@ class ContentBasePersonalizationSerializer(serializers.ModelSerializer):
                 'human_support_prompt': team.human_support_prompt
             }
         except Team.DoesNotExist:
-            return None
+            project = Project.objects.get(uuid=project_uuid)
+            return {
+                'human_support': project.human_support,
+                'human_support_prompt': project.human_support_prompt
+            }
 
     def update(self, instance, validated_data):
         agent_data = validated_data.get("agent")
@@ -199,7 +204,10 @@ class ContentBasePersonalizationSerializer(serializers.ModelSerializer):
                         agent_usecase.rollback_human_support_to_team(team=team, user=self.context.get('request').user)
 
             except Team.DoesNotExist:
-                pass
+                project = Project.objects.get(uuid=project_uuid)
+                project.human_support = team_data.get('human_support', project.human_support)
+                project.human_support_prompt = team_data.get('human_support_prompt', project.human_support_prompt)
+                project.save()
 
         # Handle agent updates
         if agent_data:


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Introduce inline agents architecture with Bedrock backend and models
  - Add models: Agent, Guardrail, Version, IntegratedAgent, Supervisor, InlineAgentMessage
  - Implement BedrockTeamAdapter and BedrockBackend for agent invocation
  - Add repository and adapter logic for team and supervisor retrieval
  - Add Django migrations for new models and fields

- Add rationale and trace observers for inline agent traces
  - Implement rationale observer for Bedrock-based rationale improvement
  - Add trace saving observer and S3 upload logic
  - Integrate observers into event manager

- Extend and fix project, API, and serializer logic for inline agents
  - Add inline_agent_switch and rationale_switch to Project model
  - Update APIs to fallback to Project fields if Team does not exist
  - Add endpoints and serializers for inline agent conversations

- Add comprehensive tests and factories for inline agents
  - Factories for all new models and test coverage for adapters, repositories, and API endpoints


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>30 files</summary><table>
<tr>
  <td><strong>adapter.py</strong><dd><code>Implement BedrockTeamAdapter for external team dict construction</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-4d92e05d2b06122eea4c49b692b6c82e88c3e05995435411d94246c9fb4f4498">+144/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>backend.py</strong><dd><code>Implement BedrockBackend for agent invocation and trace handling</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-5c56245ed7926a9068fadb4ef081087f17d06000188307f79100a1d49355bc7a">+138/-6</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>repository.py</strong><dd><code>Add abstract TeamRepository base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-cd3ebb57f0ce1a6731a91dd4334381f3c42fff571d89ff247d5a657c6dcdf27a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>views.py</strong><dd><code>Update message API to use inline agents and fix imports</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-94740ab2182ee00e7bae414ce768768b24f60544360f7b13a66d986e0a333170">+31/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>events.py</strong><dd><code>Register rationale and trace observers for inline agents</code>&nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-32fbd1950ab9cdde7a0e3139d4416b99d605d316c0a6f500c122279460e02eb6">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Expose Supervisor model in backends package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-23367149ccc40d9dcea53d7cca84103582af65c2c75029887a09d2ca71236534">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add Supervisor model for Bedrock inline agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-e32f0e6c9504fcee725f31b6e783b694ffafc87152d695038cee819748ebbc62">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository.py</strong><dd><code>Implement BedrockSupervisorRepository for supervisor retrieval</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-bda3fdc372aa2bb6f3807d9597d94ec1a8cc0cd50cbaf695f34b0143bb9367a1">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0001_initial.py</strong><dd><code>Initial migration for Agent, Guardrail, Version, IntegratedAgent</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-c2608f1cb7d476ecb2e8c73466da7a85a432168f67f8f9f901807683e98f5716">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0002_supervisor.py</strong><dd><code>Migration for Supervisor model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-6d604d56eb509c5eb066c166cf1e25633ecb9dc06cce272e8007cba91ef3fdbc">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add models for inline agents, guardrails, versions, messages</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-b9e2b350af9e7736400b9a2a344fa55e746e349e59857e206233a523f28538f8">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exceptions.py</strong><dd><code>Add TeamDoesNotExist exception for team repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-bbd4df4ec62c73c5531c08707cd19ade899585b7c7f7261cb21fb21a68b20b2e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository.py</strong><dd><code>Implement ORMTeamRepository for inline agent team retrieval</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-effd43cc89f1c1863337dbcf2d2cad6f0e523dc538144d426f180e2728fc71b6">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>routers.py</strong><dd><code>Add endpoint for inline conversations in logs API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-2ea861ac666b4a1701b545d85452100c26b7f6234172a4f9b01dfdb072c59d96">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Add serializer for InlineAgentMessage conversations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-9daec3544f8ce1cf76d3538bd5276c260cb1008d0c0553d6a5800e98f08b6302">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>views.py</strong><dd><code>Add InlineConversationsViewset for listing inline agent messages</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-ad9c106f5c42f57204365a8520369c1a31d075db8ed6c1813bac4ec4b9892cef">+48/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>paginations.py</strong><dd><code>Add InlineConversationsCursorPagination for inline conversations</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-27e93093c8999249e9fa4d1ef303c5911534c71432b00495f3502d0a3de158ca">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0011_alter_project_agents_backend.py</strong><dd><code>Migration: set default agents_backend to BedrockBackend</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-b580b7d0e4d678d90dd07d35b22682b781ee81816d7f9e1b4563e4dde6bcd54c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0012_project_inline_agent_switch_project_rationale_switch.py</strong><dd><code>Migration: add inline_agent_switch and rationale_switch to Project</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-6d4ed80747586c6cea178617b5b4c9071f002b89d4c2fe116d398fcdba956685">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add inline_agent_switch and rationale_switch fields to Project</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-87eeaf1efcebc36b9529824887f7669c614f8e283608aec4d54e49fc5963465b">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bedrock.py</strong><dd><code>Add upload_inline_traces for S3 trace upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-e83eb7efc618d91cd473072ad330c9de04e53520fc1149c27da92b24f76497eb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list.py</strong><dd><code>Add list_last_inline_messages for inline agent message retrieval</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-ee90b158ac14b7bcbc86e804504b8ad5da41dbeb42a4c7d565016f8d602b6817">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>projects_use_case.py</strong><dd><code>Enable inline_agent_switch for eligible projects on creation</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-1f3626ed4ae3f8df2bab1b09fb002959dfdf5f6004e9a9732db32cf343487a73">+2/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Route messages to inline agents if enabled on project</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-9673cc75a4d032cba669db86e8c2d97ff0e8702b87e263eee30ae54a6e570536">+8/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>actions_client.py</strong><dd><code>Refactor action client selection for preview and multi-agent</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-604d2502c4667ed105864c255bc9d3f0f6000e1a8225e3ef3020105e35a1bf4d">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>invoke.py</strong><dd><code>Add Celery task for starting inline agents with Redis logic</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-97c35bb189d07f4b71123c64da849100810da680b81192c55fadede61785b7f2">+164/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Refactor to delegate inline agent logic and action clients</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-6018a8f6f5d0aee0d720e66112b7288a282a58a9b3bfa6ec12fb885198630730">+41/-85</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rationale_observer.py</strong><dd><code>Add Bedrock-based rationale observer for inline agent traces</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-57b388db1ea113ec85ee0a92271dd3c183a9362459dd97809a1713bd573f6a70">+376/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>save_traces.py</strong><dd><code>Add SaveTracesObserver for saving inline agent traces to S3</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-ab699dee0245bf6d6b981dc4ed8449868c0c562d656c97b2207ec89efb4e3c03">+106/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>summary.py</strong><dd><code>Add SummaryTracesObserver for summarizing traces (preview mode)</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-83601bc2eab5b53c9c99d3b5a71e6942f4c8d6a4239472154b79fe7a29d308ef">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>inline_factories.py</strong><dd><code>Add factories for Agent, IntegratedAgent, Version, Guardrail, </code><br><code>Supervisor</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-85b763f9e583901ceceba7c91f6f8b9786a699296eebaf6436293a8cf54313fc">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_adapter.py</strong><dd><code>Add tests for BedrockTeamAdapter external team conversion</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-71977385ce3ec66f47816300e148d08e315ce11ecb4190001ba846a1463d8e21">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tests.py</strong><dd><code>Add tests for BedrockSupervisorRepository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-55b20a92587191a4f8466416acd11a613f81f0dde39d9d7f677e0f330fb10cee">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tests.py</strong><dd><code>Add tests for InlineConversationsViewset and message retrieval</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-0f6ca4c1688e109ba52ef532497e703784fecf2580dc71322159cd2912079414">+215/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>inline_factories.py</strong><dd><code>Add factory for InlineAgentMessage for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-f469955fad2ee077b1ee84e361e41232cd6ed37fdc479b385c64aff072adaa76">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>views.py</strong><dd><code>Fallback to Project for rationale if Team missing; update rationale</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-7b9096cbce9c49d7f63206698759390ab97b228b285e9390bca131485530938e">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Fallback to Project for human support if Team missing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-f036e2ad0a4fee4aa5fc10ea4edf88e83fcae4a0a5db937aba7669690bf78cb5">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>settings.py</strong><dd><code>Add Bedrock inline agent client env vars and rationale model config</code></dd></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-6efc28803f3c19a07508b163fcc60a85df22913cbc0f7a266a06f2211f1b8319">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-f7f91e88b7f817b2008b4d45a9f4d8ecf9df620cc22b33e9ba50ca151e094306">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-9515695d4ba8d72b7c85441ba89e8f557ed36d3315617f26b3f4d2bd60547ad0">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-f99c6e6b4aad3b51ffa79438bbe1787932dda56a6e262dce1511adfe09c54285">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-6cb155d956e0364baa5ea66eba176cd3cfd0258e30a0ed34b55983064534d7dd">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/511/files#diff-9a4acb518c891f02387f513dbc5d11572e2fb7d6c3cb6f32bb710483a7d4511e">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>