### PR TITLE
Fix/staging

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -104,8 +104,7 @@ class BedrockTeamAdapter(TeamAdapter):
         sessionState = {}
         if credentials:
             sessionState["sessionAttributes"] = {"credentials": json.dumps(credentials, default=str)}
-        # if use_components:
-        #     sessionState["promptSessionAttributes"]["format_components"] = Components().get_all_formats_string()
+
         return sessionState
 
     @classmethod
@@ -123,8 +122,6 @@ class BedrockTeamAdapter(TeamAdapter):
                     "actionGroups": agent["actionGroups"],
                     "foundationModel": agent["foundationModel"],
                     "agentCollaboration": agent["agentCollaboration"],
-                    # "promptOverrideConfiguration": cls.__get_collaborator_prompt_override_configuration(),
-                    # "idleSessionTTLInSeconds": agent.idle_session_ttl_in_seconds,
                 }
             )
         return collaborators

--- a/nexus/inline_agents/team/repository.py
+++ b/nexus/inline_agents/team/repository.py
@@ -17,7 +17,7 @@ class ORMTeamRepository(TeamRepository):
             for integrated_agent in orm_team:
                 agent = integrated_agent.agent
                 skills = []
-                
+
                 skills=agent.current_version.skills
                 for index, skill in enumerate(skills):
                     for function in skill["functionSchema"]["functions"]:
@@ -27,6 +27,8 @@ class ORMTeamRepository(TeamRepository):
                                 for key, value in param_dict.items():
                                     parametros_combinados[key] = value
                             function["parameters"] = parametros_combinados
+                        elif function.get("parameters") is None:
+                            function["parameters"] = {}
                     skills[index]["actionGroupName"] = slugify(skill["actionGroupName"])
 
                 agent_dict = {

--- a/nexus/usecases/inline_agents/bedrock.py
+++ b/nexus/usecases/inline_agents/bedrock.py
@@ -20,15 +20,19 @@ class BedrockClient:
         zip_buffer: BytesIO
     ) -> Dict[str, str]:
 
-        lambda_function = self.lambda_client.create_function(
-            FunctionName=lambda_name,
-            Runtime='python3.12',
-            Timeout=180,
-            Role=lambda_role,
-            Code={'ZipFile': zip_buffer.getvalue()},
-            Handler=skill_handler
-        )
-        lambda_arn = lambda_function.get("FunctionArn")
+        try:
+            lambda_function = self.lambda_client.create_function(
+                FunctionName=lambda_name,
+                Runtime='python3.12',
+                Timeout=180,
+                Role=lambda_role,
+                Code={'ZipFile': zip_buffer.getvalue()},
+                    Handler=skill_handler
+                )
+            lambda_arn = lambda_function.get("FunctionArn")
+        except self.lambda_client.exceptions.ResourceConflictException:
+            lambda_function = self.lambda_client.get_function(FunctionName=lambda_name)
+            lambda_arn = lambda_function.get("FunctionArn")
 
         return lambda_arn
 

--- a/nexus/usecases/inline_agents/tools.py
+++ b/nexus/usecases/inline_agents/tools.py
@@ -58,13 +58,13 @@ class ToolsUseCase:
 
         project_uuid = str(project.uuid)
         action_group_executor: Dict[str, str] = self.create_lambda_function(agent_tool, tool_file, project_uuid, tool_name)
-        parameters: List[Dict] = self.handle_parameters(agent, project, agent_tool["parameters"], project_uuid)
+        parameters: List[Dict] = self.handle_parameters(agent, project, agent_tool.get("parameters", []), project_uuid)
         response = self._format_tool_response(agent_tool, tool_name, parameters, action_group_executor, str(agent.uuid))
         return response
 
     def delete_tool(self, agent: Agent, project: Project, agent_tool: Dict, tool_file, tool_name: str) -> Tuple[Dict, Dict]:
         project_uuid = str(project.uuid)
-        self.handle_parameters(agent, project, agent_tool["parameters"], project_uuid)
+        self.handle_parameters(agent, project, agent_tool.get("parameters", []), project_uuid)
         self.delete_lambda_function(tool_name)
         return
 
@@ -72,7 +72,7 @@ class ToolsUseCase:
         
         project_uuid = str(project.uuid)
         action_group_executor = self.update_lambda_function(agent_tool, tool_file, project_uuid, tool_name)
-        parameters: List[Dict] = self.handle_parameters(agent, project, agent_tool["parameters"], project_uuid)
+        parameters: List[Dict] = self.handle_parameters(agent, project, agent_tool.get("parameters", []), project_uuid)
         response = self._format_tool_response(agent_tool, tool_name, parameters, action_group_executor, str(agent.uuid))
         return response
 

--- a/nexus/usecases/inline_agents/tools.py
+++ b/nexus/usecases/inline_agents/tools.py
@@ -145,21 +145,22 @@ class ToolsUseCase:
             existing_field_keys = [field['key'] for field in flows_contact_fields.get('results', [])]
 
         fields_to_keep = []
-        for parameter in parameters:
-            field_name = list(parameter.keys())[0]
-            field_data = parameter[field_name]
-            contact_field = field_data.get("contact_field")
+        if parameters:
+            for parameter in parameters:
+                field_name = list(parameter.keys())[0]
+                field_data = parameter[field_name]
+                contact_field = field_data.get("contact_field")
 
-            if contact_field:
-                fields_to_keep.append(field_name)
-                if field_name not in existing_field_keys and field_name not in db_existing_fields:
-                    print(f"[+ 🧠 Creating contact field: {field_name} +]")
-                    self.create_contact_field(agent_obj, project, field_name, parameter, external_create=True)
-                elif field_name in existing_field_keys and field_name not in db_existing_fields:
-                    print(f"[+ 🧠 Creating contact field: {field_name} +]")
-                    self.create_contact_field(agent_obj, project, field_name, parameter, external_create=False)
+                if contact_field:
+                    fields_to_keep.append(field_name)
+                    if field_name not in existing_field_keys and field_name not in db_existing_fields:
+                        print(f"[+ 🧠 Creating contact field: {field_name} +]")
+                        self.create_contact_field(agent_obj, project, field_name, parameter, external_create=True)
+                    elif field_name in existing_field_keys and field_name not in db_existing_fields:
+                        print(f"[+ 🧠 Creating contact field: {field_name} +]")
+                        self.create_contact_field(agent_obj, project, field_name, parameter, external_create=False)
 
-            field_data.pop("contact_field", None)
+                field_data.pop("contact_field", None)
 
         self.delete_contact_fields(agent_obj, project, fields_to_keep, project_uuid)
         return parameters


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Dependencies, Configuration changes, Documentation, Other


___

### **Description**
- Introduces a comprehensive inline agent framework with Bedrock backend integration, supporting agent creation, assignment, invocation, and messaging.

- Adds new models for agents, credentials, versions, guardrails, supervisor, and inline agent messages, with corresponding migrations.

- Implements BedrockTeamAdapter and BedrockBackend for converting internal teams and invoking agents via Bedrock, including trace and rationale handling.

- Provides API endpoints and serializers for managing inline agents, credentials, assignments, and project components.

- Adds Celery tasks for orchestrating inline agent invocation (`start_inline_agents`) and trace event persistence.

- Introduces multiple event observers (RationaleObserver, SummaryTracesObserver, SaveTracesObserver) for rationale improvement, trace summarization, and trace saving.

- Enhances project and agent models to support inline agent switches, rationale switches, and component usage.

- Adds test cases and factories for inline agent models, backend adapters, supervisor repository, and API endpoints.

- Updates Dockerfile to install the `html2text` dependency.

- Refactors message routing, agent API routes, and preview flows to leverage the new inline agent system.

- Adds custom pagination, error handling, and permission logic for inline agent message history.

- Updates settings and configuration to support Bedrock inline agent credentials and backend selection.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>41 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>rationale_observer.py</strong><dd><code>Add RationaleObserver for Bedrock-based rationale improvement and </code><br><code>messaging</code></dd></summary>
<hr>

router/traces_observers/rationale_observer.py

<li>Introduces a new <code>RationaleObserver</code> class for observing and improving <br>rationale messages using Amazon Bedrock.<br> <li> Implements logic for extracting, validating, and improving rationale <br>traces, including first and subsequent rationales.<br> <li> Integrates with Celery for asynchronous message sending and saving <br>inline messages to the database.<br> <li> Provides detailed instruction templates for rationale improvement and <br>validation.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-57b388db1ea113ec85ee0a92271dd3c183a9362459dd97809a1713bd573f6a70">+378/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Add API views for inline agent management and credentials</code></dd></summary>
<hr>

nexus/inline_agents/api/views.py

<li>Adds a comprehensive set of API views for managing inline agents, <br>credentials, assignments, and project components.<br> <li> Implements endpoints for pushing, updating, assigning, and listing <br>agents, as well as handling credentials and team views.<br> <li> Introduces internal communication permissions and VTEX app-specific <br>endpoints.<br> <li> Provides project component management via API.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-a889c13e77d0e1263b345dfa881f0bae18375bbf30c00f51fb686ab207ca66cd">+402/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Implement BedrockTeamAdapter for team-to-external conversion</code></dd></summary>
<hr>

inline_agents/backends/bedrock/adapter.py

<li>Implements the BedrockTeamAdapter for converting internal team <br>structures to Bedrock-compatible external representations.<br> <li> Handles credentials, session state, collaborators, knowledge bases, <br>and guardrails formatting.<br> <li> Provides methods for formatting supervisor instructions and prompt <br>override configurations.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-4d92e05d2b06122eea4c49b692b6c82e88c3e05995435411d94246c9fb4f4498">+274/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tools.py</strong><dd><code>Add ToolsUseCase for agent tool and contact field management</code></dd></summary>
<hr>

nexus/usecases/inline_agents/tools.py

<li>Adds ToolsUseCase class for managing agent tools (skills), including <br>creation, updating, and deletion of Lambda functions.<br> <li> Handles contact field management and tool parameter synchronization <br>with external systems.<br> <li> Provides logic for updating agent versions and display skills.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-051f0d35ec5e8db9a24c3924c63c413616342ba6a1f06c7e9ed384887ccbf4f2">+216/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Update rationale improvement and integrate start_inline_agents task</code></dd></summary>
<hr>

router/tasks/tasks.py

<li>Updates rationale improvement logic to match new invalid thought <br>criteria and principles.<br> <li> Refactors imports and code organization for clarity.<br> <li> Integrates with new start_inline_agents task for multi-agent support.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-6018a8f6f5d0aee0d720e66112b7288a282a58a9b3bfa6ec12fb885198630730">+41/-85</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>components.py</strong><dd><code>Add Components class for message format templates and instructions</code></dd></summary>
<hr>

nexus/inline_agents/components.py

<li>Introduces a Components class with JSON templates for various message <br>formats (simple text, quick replies, list, CTA URL, catalog).<br> <li> Provides instruction sets for each component type.<br> <li> Includes methods to retrieve all formats as a list or string.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-40e08e1fb2bcff76aff469a5abd660387457bf0e507bc5438ac1c4b000029e8f">+161/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>invoke.py</strong><dd><code>Add start_inline_agents Celery task for inline agent orchestration</code></dd></summary>
<hr>

router/tasks/invoke.py

<li>Adds a Celery task <code>start_inline_agents</code> for orchestrating inline agent <br>invocation with Redis-based message queuing.<br> <li> Handles message concatenation, task revocation, and WebSocket status <br>updates.<br> <li> Integrates with backend agent invocation and dispatches responses.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-97c35bb189d07f4b71123c64da849100810da680b81192c55fadede61785b7f2">+184/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend.py</strong><dd><code>Implement BedrockBackend for agent invocation and trace handling</code></dd></summary>
<hr>

inline_agents/backends/bedrock/backend.py

<li>Implements BedrockBackend for invoking agents via Bedrock, including <br>trace handling and WebSocket updates.<br> <li> Integrates with event observers for trace and rationale processing.<br> <li> Handles saving inline messages and traces to the database.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-5c56245ed7926a9068fadb4ef081087f17d06000188307f79100a1d49355bc7a">+149/-6</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Add models for inline agents, credentials, and messages</code>&nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/models.py

<li>Adds models for Agent, IntegratedAgent, Version, AgentCredential, <br>ContactField, Guardrail, and InlineAgentMessage.<br> <li> Implements credential encryption/decryption and validation logic.<br> <li> Supports trace path generation for inline agent messages.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-b9e2b350af9e7736400b9a2a344fa55e746e349e59857e206233a523f28538f8">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>broadcast.py</strong><dd><code>Add SimulateWhatsAppBroadcastHTTPClient for WhatsApp message </code><br><code>simulation</code></dd></summary>
<hr>

router/clients/preview/simulator/broadcast.py

<li>Adds SimulateWhatsAppBroadcastHTTPClient for simulating WhatsApp <br>broadcast messages with JSON extraction and formatting.<br> <li> Enhances SimulateBroadcast with improved message handling.<br> <li> Provides methods for parsing and fixing JSON message strings.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-d6b25124901c8753417ad68f486124eb4d0f5e784ad35727c08256dcfd091c1b">+104/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Add InlineConversationsViewset for inline message history</code></dd></summary>
<hr>

nexus/logs/api/views.py

<li>Adds InlineConversationsViewset for paginated retrieval of inline <br>agent messages by contact and date range.<br> <li> Implements sorting and error handling for missing parameters.<br> <li> Integrates with custom pagination and serializers.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-ad9c106f5c42f57204365a8520369c1a31d075db8ed6c1813bac4ec4b9892cef">+52/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Add serializers for inline agents and credentials</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/api/serializers.py

<li>Adds serializers for IntegratedAgent, Agent, and <br>ProjectCredentialsList.<br> <li> Handles serialization of agent skills, credentials, and assignment <br>status.<br> <li> Supports credential value masking for confidential fields.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-ff3ad4ffd6e7ad0510aa5de225f698e656fd92f3a677a65f21f9a5a0e25e42b6">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Use start_inline_agents for inline agent preview flows</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/actions/api/views.py

<li>Updates preview message handling to use start_inline_agents for inline <br>agent flows.<br> <li> Refactors imports and logic for clarity and maintainability.<br> <li> Integrates with new agent invocation flow.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-94740ab2182ee00e7bae414ce768768b24f60544360f7b13a66d986e0a333170">+31/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>summary.py</strong><dd><code>Add SummaryTracesObserver for trace summarization and preview updates</code></dd></summary>
<hr>

router/traces_observers/summary.py

<li>Adds SummaryTracesObserver for generating and sending concise trace <br>summaries using OpenAI.<br> <li> Integrates with WebSocket for real-time trace updates in preview mode.<br> <li> Handles error cases and language-specific summarization.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-83601bc2eab5b53c9c99d3b5a71e6942f4c8d6a4239472154b79fe7a29d308ef">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update.py</strong><dd><code>Add UpdateAgentUseCase for updating agents and credentials</code></dd></summary>
<hr>

nexus/usecases/inline_agents/update.py

<li>Adds UpdateAgentUseCase for updating agent details, tools, and <br>credentials.<br> <li> Implements credential update, creation, and deletion logic.<br> <li> Provides method to update credential values with encryption support.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-aaefee2a790026f070281136b4b7852639956d04d7e10855d3bceb1534752d26">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>save_traces.py</strong><dd><code>Add SaveTracesObserver for trace event persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

router/traces_observers/save_traces.py

<li>Adds SaveTracesObserver for saving trace events and inline messages to <br>the database and S3.<br> <li> Implements Celery task for asynchronous trace saving.<br> <li> Provides utility functions for trace event serialization and S3 <br>upload.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-ab699dee0245bf6d6b981dc4ed8449868c0c562d656c97b2207ec89efb4e3c03">+106/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create.py</strong><dd><code>Add CreateAgentUseCase for agent and credential creation</code>&nbsp; </dd></summary>
<hr>

nexus/usecases/inline_agents/create.py

<li>Adds CreateAgentUseCase for creating agents, tools, and credentials.<br> <li> Handles credential encryption and association with agents.<br> <li> Supports updating existing credentials and agent creation workflow.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-b5f50d433ffbfffe7a12b4bc6d0c8352a8f65b1beba41b751cc6d913366d0edb">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repository.py</strong><dd><code>Add abstract TeamRepository for team data access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/team/repository.py

<li>Adds abstract TeamRepository class with a get_team method signature.<br> <li> Prepares for team repository implementations.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-cd3ebb57f0ce1a6731a91dd4334381f3c42fff571d89ff247d5a657c6dcdf27a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Improve rationale and trace handling for inline agents in API views</code></dd></summary>
<hr>

nexus/agents/api/views.py

<li>Changed trace retrieval to use <code>get_inline_traces</code> instead of <br><code>get_traces</code>.<br> <li> Enhanced rationale retrieval and update logic to fallback to <br>project-level fields if the Team does not exist.<br> <li> Ensured rationale updates are saved to the Project model as well.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-7b9096cbce9c49d7f63206698759390ab97b228b285e9390bca131485530938e">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Update AgentMessage trace base path to inline_traces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/agents/models.py

<li>Changed the <code>TRACES_BASE_PATH</code> of <code>AgentMessage</code> from "traces" to <br>"inline_traces".


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-282c44f70415799ee6707ca7f8937ab7cdedbf8458dc815d8c24b032eaf3c16e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>events.py</strong><dd><code>Register inline trace observers in event manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/events.py

<li>Subscribed new observers for inline trace events: RationaleObserver, <br>SummaryTracesObserver, and SaveTracesObserver.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-32fbd1950ab9cdde7a0e3139d4416b99d605d316c0a6f500c122279460e02eb6">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Expose Supervisor model in inline_agents backend package</code>&nbsp; </dd></summary>
<hr>

nexus/inline_agents/backends/__init__.py

<li>Added import and export of the Supervisor model from bedrock backend.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-23367149ccc40d9dcea53d7cca84103582af65c2c75029887a09d2ca71236534">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Add Supervisor model for Bedrock inline agents backend</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/backends/bedrock/models.py

<li>Added a new Supervisor model with fields for instructions, prompts, <br>action groups, and knowledge bases, including component-specific <br>fields.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-e32f0e6c9504fcee725f31b6e783b694ffafc87152d695038cee819748ebbc62">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repository.py</strong><dd><code>Add BedrockSupervisorRepository for supervisor config retrieval</code></dd></summary>
<hr>

nexus/inline_agents/backends/bedrock/repository.py

<li>Added BedrockSupervisorRepository with logic to retrieve supervisor <br>configuration for a project, including prompt and action group <br>selection based on project settings.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-bda3fdc372aa2bb6f3807d9597d94ec1a8cc0cd50cbaf695f34b0143bb9367a1">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exceptions.py</strong><dd><code>Add TeamDoesNotExist exception for inline agent teams</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/team/exceptions.py

- Added a custom exception class TeamDoesNotExist.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-bbd4df4ec62c73c5531c08707cd19ade899585b7c7f7261cb21fb21a68b20b2e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repository.py</strong><dd><code>Add ORMTeamRepository for integrated agent team retrieval</code></dd></summary>
<hr>

nexus/inline_agents/team/repository.py

<li>Added ORMTeamRepository for retrieving integrated agent team data for <br>a project, including skill parameter normalization.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-effd43cc89f1c1863337dbcf2d2cad6f0e523dc538144d426f180e2728fc71b6">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Improve team/project fallback for human support in serializers</code></dd></summary>
<hr>

nexus/intelligences/api/serializers.py

<li>Enhanced team retrieval to fallback to project-level human support <br>fields if Team does not exist.<br> <li> Updated logic to save human support fields to Project if Team is <br>missing during update.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-f036e2ad0a4fee4aa5fc10ea4edf88e83fcae4a0a5db937aba7669690bf78cb5">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Add serializer for InlineAgentMessage conversations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/logs/api/serializers.py

<li>Added InlineConversationSerializer for serializing InlineAgentMessage <br>objects.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-9daec3544f8ce1cf76d3538bd5276c260cb1008d0c0553d6a5800e98f08b6302">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>paginations.py</strong><dd><code>Add cursor pagination for inline conversations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/paginations.py

<li>Added InlineConversationsCursorPagination for paginating inline <br>conversations.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-27e93093c8999249e9fa4d1ef303c5911534c71432b00495f3502d0a3de158ca">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Refactor Project model for inline agent and component support</code></dd></summary>
<hr>

nexus/projects/models.py

<li>Removed dependency on BackendsRegistry for agents_backend choices.<br> <li> Set default agents_backend to "BedrockBackend".<br> <li> Added rationale_switch, inline_agent_switch, and use_components <br>boolean fields to Project model.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-87eeaf1efcebc36b9529824887f7669c614f8e283608aec4d54e49fc5963465b">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bedrock.py</strong><dd><code>Add inline trace upload and retrieval to Bedrock file database</code></dd></summary>
<hr>

nexus/task_managers/file_database/bedrock.py

<li>Added methods to upload and retrieve inline traces to/from a custom S3 <br>bucket.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-e83eb7efc618d91cd473072ad330c9de04e53520fc1149c27da92b24f76497eb">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agents.py</strong><dd><code>Add inline trace retrieval to AgentUsecase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/agents/agents.py

<li>Added get_inline_traces method to retrieve inline agent traces from <br>storage.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-54124e721a16234f886f7dca38d95a9d558c8168f0ffea7cbae148dc82bb35da">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>assign.py</strong><dd><code>Add AssignAgentsUsecase for agent-project assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/inline_agents/assign.py

<li>Added AssignAgentsUsecase for assigning and unassigning agents to <br>projects.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-a00e05c7ab197ee846f13d982e43ded4812c99032ee6fb438a477d290943aff3">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bedrock.py</strong><dd><code>Add BedrockClient for AWS Lambda management in inline agents</code></dd></summary>
<hr>

nexus/usecases/inline_agents/bedrock.py

<li>Added BedrockClient class for managing AWS Lambda functions for inline <br>agents, including create, update, and delete operations.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-e9d3417df8e5f85531d7b9717d4b76f46bed05a62667e354383d101d7971969c">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get.py</strong><dd><code>Add use cases for retrieving inline agents and credentials</code></dd></summary>
<hr>

nexus/usecases/inline_agents/get.py

<li>Added use cases for retrieving active inline agents and their <br>credentials for a project.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-e5f3b7676d9aed8fac6e2d88216d547dad5e16a7a3cb430b6333ecea3f804d1c">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>instructions.py</strong><dd><code>Add InstructionsUseCase for composing agent instructions</code>&nbsp; </dd></summary>
<hr>

nexus/usecases/inline_agents/instructions.py

<li>Added InstructionsUseCase for handling and composing agent <br>instructions from components and guardrails.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-c8f75779a95decd0dd40b7c72e3275028d5928c757ba5f4a9ed417924a68331c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list.py</strong><dd><code>Add listing of last inline agent messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/logs/list.py

<li>Added method to list last inline agent messages for a project/contact <br>in a date range.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-ee90b158ac14b7bcbc86e804504b8ad5da41dbeb42a4c7d565016f8d602b6817">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>projects_use_case.py</strong><dd><code>Enable inline_agent_switch on project creation for valid users/orgs</code></dd></summary>
<hr>

nexus/usecases/projects/projects_use_case.py

<li>Updated project creation logic to enable inline_agent_switch for valid <br>users/orgs instead of creating multi-agent base.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-1f3626ed4ae3f8df2bab1b09fb002959dfdf5f6004e9a9732db32cf343487a73">+2/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>send_message.py</strong><dd><code>Add helpers for extracting and formatting JSON messages</code>&nbsp; &nbsp; </dd></summary>
<hr>

router/clients/flows/http/send_message.py

<li>Enhanced JSON extraction from text with new helper methods for message <br>handling.<br> <li> Added string_to_simple_text utility for message formatting.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-26ac23dd5fc05af4dd48b29245f30bbed1f8a5ea152716d1c317225cac94f7b1">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Route messages to inline agents if enabled on project</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

router/main.py

<li>Changed message routing to use start_inline_agents if the project has <br>inline_agent_switch enabled.<br> <li> Removed unused imports and code for multi-agent routing.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-9673cc75a4d032cba669db86e8c2d97ff0e8702b87e263eee30ae54a6e570536">+8/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>actions_client.py</strong><dd><code>Add action client selection logic for router tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

router/tasks/actions_client.py

<li>Added function to select appropriate action clients for broadcasting <br>and flow start, supporting preview and multi-agent/component <br>scenarios.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-604d2502c4667ed105864c255bc9d3f0f6000e1a8225e3ef3020105e35a1bf4d">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.py</strong><dd><code>Add tests for inline agent use cases and credential handling</code></dd></summary>
<hr>

nexus/inline_agents/tests.py

<li>Adds extensive test cases for agent assignment, creation, updating, <br>and credential management.<br> <li> Includes tests for pushing agents, updating tools and credentials, and <br>retrieving credentials by project.<br> <li> Mocks Bedrock client interactions for isolated testing.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-8908412828b342c0b24c618058dbd20601a437214a93f41d9d1d67c25051665f">+308/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tests.py</strong><dd><code>Add tests for InlineConversationsViewset and inline message retrieval</code></dd></summary>
<hr>

nexus/logs/api/tests.py

<li>Adds test cases for the new InlineConversationsViewset, covering <br>listing, filtering, pagination, and permissions.<br> <li> Ensures correct retrieval and ordering of inline agent messages by <br>contact and project.<br> <li> Tests error handling for missing parameters and unauthorized access.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-0f6ca4c1688e109ba52ef532497e703784fecf2580dc71322159cd2912079414">+215/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inline_factories.py</strong><dd><code>Add test factories for inline agent backend models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/tests/inline_factories.py

<li>Added a new test factory module for inline agent-related models, <br>including factories for Agent, IntegratedAgent, Version, Guardrail, <br>and Supervisor.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-85b763f9e583901ceceba7c91f6f8b9786a699296eebaf6436293a8cf54313fc">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_adapter.py</strong><dd><code>Add BedrockTeamAdapter test for to_external method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/tests/test_adapter.py

<li>Added a new test case for the BedrockTeamAdapter, testing the <br><code>to_external</code> method with supervisor and agent data.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-71977385ce3ec66f47816300e148d08e315ce11ecb4190001ba846a1463d8e21">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tests.py</strong><dd><code>Add tests for BedrockSupervisorRepository supervisor retrieval</code></dd></summary>
<hr>

nexus/inline_agents/backends/bedrock/tests.py

<li>Added test case for BedrockSupervisorRepository to verify supervisor <br>retrieval logic.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-55b20a92587191a4f8466416acd11a613f81f0dde39d9d7f677e0f330fb10cee">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inline_factories.py</strong><dd><code>Add InlineAgentMessageFactory for test data creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/inline_agents/tests/inline_factories.py

- Added factory for InlineAgentMessage for use in tests.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-f469955fad2ee077b1ee84e361e41232cd6ed37fdc479b385c64aff072adaa76">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>routers.py</strong><dd><code>Update agent API routes for inline agent endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/agents/api/routers.py

<li>Updates agent-related API routes to use new inline agent views and <br>endpoints.<br> <li> Adds routes for project components and VTEX app-specific endpoints.<br> <li> Refactors import statements for clarity.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-f329355043eeaa223806afa2bc3a7d6d755f56b70352e269f05431b62721300d">+26/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>routers.py</strong><dd><code>Add route for inline conversations in logs API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/logs/api/routers.py

<li>Adds route for inline conversations using InlineConversationsViewset.<br> <li> Updates import statements for new viewset.<br> <li> Integrates inline conversation history into logs API.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-2ea861ac666b4a1701b545d85452100c26b7f6234172a4f9b01dfdb072c59d96">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Add Bedrock inline agent client credentials to settings</code>&nbsp; &nbsp; </dd></summary>
<hr>

nexus/settings.py

<li>Added BEDROCK_AGENT_INLINE_CLIENT_ID and <br>BEDROCK_AGENT_INLINE_CLIENT_SECRET environment variables.<br> <li> Minor formatting/comment changes.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-6efc28803f3c19a07508b163fcc60a85df22913cbc0f7a266a06f2211f1b8319">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add html2text dependency installation to Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Added a new RUN command to install the <code>html2text==2024.2.26</code> Python <br>package.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>0001_initial.py</strong><dd><code>Initial migration for inline_agents app models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/migrations/0001_initial.py

<li>Added initial migration for inline_agents app, creating Agent, <br>Guardrail, Version, and IntegratedAgent models.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-c2608f1cb7d476ecb2e8c73466da7a85a432168f67f8f9f901807683e98f5716">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0002_supervisor.py</strong><dd><code>Migration to add Supervisor model to inline_agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/migrations/0002_supervisor.py

<li>Added migration to create the Supervisor model with fields for <br>prompts, action groups, and knowledge bases.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-6d604d56eb509c5eb066c166cf1e25633ecb9dc06cce272e8007cba91ef3fdbc">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0003_agent_source_type_inlineagentmessage_contactfield_and_more.py</strong><dd><code>Migration for Agent source_type and new inline agent models</code></dd></summary>
<hr>

nexus/inline_agents/migrations/0003_agent_source_type_inlineagentmessage_contactfield_and_more.py

<li>Added migration to extend Agent with source_type and create <br>InlineAgentMessage, ContactField, and AgentCredential models.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-18e67fe85a6c40ea331124ea05e3d2db40811209ee0983c4e19f4ca0d7947230">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0004_supervisor_components_human_support_prompt_and_more.py</strong><dd><code>Migration to add component prompt fields to Supervisor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/migrations/0004_supervisor_components_human_support_prompt_and_more.py

<li>Added migration to add components_human_support_prompt and <br>components_prompt fields to Supervisor model.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-05f5af08fc8d879f6450f272bf12ff9b6bc3b9f4f6905af2cd89fd312c9ad8ed">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0011_alter_project_agents_backend.py</strong><dd><code>Migration to update default agents_backend in Project</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/projects/migrations/0011_alter_project_agents_backend.py

<li>Migration to set default value of agents_backend to 'BedrockBackend' <br>in Project model.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-b580b7d0e4d678d90dd07d35b22682b781ee81816d7f9e1b4563e4dde6bcd54c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0012_project_inline_agent_switch_project_rationale_switch.py</strong><dd><code>Migration to add inline_agent_switch and rationale_switch to Project</code></dd></summary>
<hr>

nexus/projects/migrations/0012_project_inline_agent_switch_project_rationale_switch.py

<li>Migration to add inline_agent_switch and rationale_switch boolean <br>fields to Project model.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-6d4ed80747586c6cea178617b5b4c9071f002b89d4c2fe116d398fcdba956685">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0013_project_use_components.py</strong><dd><code>Migration to add use_components field to Project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/projects/migrations/0013_project_use_components.py

- Migration to add use_components boolean field to Project model.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-ba9291687937c39b44dfcc7cd33ae47530eb95fb8e3e0d2f5607bf29903f21d7">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-f7f91e88b7f817b2008b4d45a9f4d8ecf9df620cc22b33e9ba50ca151e094306">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-9515695d4ba8d72b7c85441ba89e8f557ed36d3315617f26b3f4d2bd60547ad0">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-f99c6e6b4aad3b51ffa79438bbe1787932dda56a6e262dce1511adfe09c54285">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-6cb155d956e0364baa5ea66eba176cd3cfd0258e30a0ed34b55983064534d7dd">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/517/files#diff-9a4acb518c891f02387f513dbc5d11572e2fb7d6c3cb6f32bb710483a7d4511e">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>