### PR TITLE
Temp fix: Turn off supervisor on specific project

### DIFF
--- a/nexus/logs/api/views.py
+++ b/nexus/logs/api/views.py
@@ -1,3 +1,4 @@
+import os
 import pendulum
 
 from rest_framework import views
@@ -77,6 +78,10 @@ class TagPercentageViewSet(
         if not started_day or not ended_day:
             return Response({"error": "Invalid date format for started_day or ended_day"}, status=400)
 
+        unavaible_service_project_uuid = os.getenv("TEMP_JU_DA_BOLSA")
+        if project_uuid == unavaible_service_project_uuid:
+            return Response([], status=200)
+
         source = request.query_params.get('source', 'router')
         message_logs = MessageLog.objects.filter(
             created_at__date__gte=started_day,
@@ -149,6 +154,10 @@ class MessageHistoryViewset(
         if not started_day or not ended_day:
             return Response({"error": "Invalid date format for started_day or ended_day"}, status=400)
 
+        unavaible_service_project_uuid = os.getenv("TEMP_JU_DA_BOLSA")
+        if project_uuid == unavaible_service_project_uuid:
+            return Response([], status=200)
+
         params["created_at__date__gte"] = started_day
         params["created_at__date__lte"] = ended_day
 
@@ -157,7 +166,6 @@ class MessageHistoryViewset(
 
         source = self.request.query_params.get('source', 'router')
         params["source"] = source
-
 
         project = Project.objects.get(uuid=project_uuid)
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Temporarily disables supervisor functionality for a specific project.

- Returns empty response for affected project based on environment variable.

- Adds environment variable check for project UUID in two API endpoints.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Disable supervisor for project based on environment variable</code></dd></summary>
<hr>

nexus/logs/api/views.py

<li>Imports <code>os</code> to access environment variables.<br> <li> Adds check for <code>TEMP_JU_DA_BOLSA</code> environment variable in two endpoints.<br> <li> Returns empty response if project UUID matches the unavailable <br>service.<br> <li> Ensures supervisor features are disabled for the specified project.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/523/files#diff-ad9c106f5c42f57204365a8520369c1a31d075db8ed6c1813bac4ec4b9892cef">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>