### PR TITLE
Fix: Disable supervisor endpoint

### DIFF
--- a/nexus/logs/api/views.py
+++ b/nexus/logs/api/views.py
@@ -78,8 +78,8 @@ class TagPercentageViewSet(
         if not started_day or not ended_day:
             return Response({"error": "Invalid date format for started_day or ended_day"}, status=400)
 
-        unavaible_service_project_uuid = os.getenv("TEMP_JU_DA_BOLSA")
-        if project_uuid == unavaible_service_project_uuid:
+        service_available = os.getenv("SUPERVISOR_SERVICE_AVAILABLE")
+        if service_available:
             return Response([], status=200)
 
         source = request.query_params.get('source', 'router')
@@ -154,8 +154,8 @@ class MessageHistoryViewset(
         if not started_day or not ended_day:
             return Response({"error": "Invalid date format for started_day or ended_day"}, status=400)
 
-        unavaible_service_project_uuid = os.getenv("TEMP_JU_DA_BOLSA")
-        if project_uuid == unavaible_service_project_uuid:
+        service_available = os.getenv("SUPERVISOR_SERVICE_AVAILABLE")
+        if service_available:
             return Response([], status=200)
 
         params["created_at__date__gte"] = started_day


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace project UUID check with service availability flag

- Disable supervisor endpoint based on SUPERVISOR_SERVICE_AVAILABLE

- Remove dependency on TEMP_JU_DA_BOLSA environment variable


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Use SUPERVISOR_SERVICE_AVAILABLE to control supervisor endpoint</code></dd></summary>
<hr>

nexus/logs/api/views.py

<li>Replaced check for unavailable service project UUID with <br>SUPERVISOR_SERVICE_AVAILABLE flag<br> <li> Changed logic to return empty response if supervisor service is <br>available<br> <li> Removed use of TEMP_JU_DA_BOLSA environment variable


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/525/files#diff-ad9c106f5c42f57204365a8520369c1a31d075db8ed6c1813bac4ec4b9892cef">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>