### PR TITLE
change source type for listing agents available for the app

### DIFF
--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -272,7 +272,7 @@ class VtexAppOfficialAgentsView(APIView):
         project_uuid = kwargs.get("project_uuid")
         search = self.request.query_params.get("search")
 
-        agents = Agent.objects.filter(is_official=True, source_type=Agent.PLATFORM)
+        agents = Agent.objects.filter(is_official=True, source_type=Agent.VTEX_APP)
 
         if search:
             query_filter = Q(name__icontains=search)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update agent source type filter to use `VTEX_APP`

- Ensure only VTEX app agents are listed for the app


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Update agent source type filter to VTEX_APP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/inline_agents/api/views.py

<li>Changed agent filter from <code>PLATFORM</code> to <code>VTEX_APP</code> for <code>is_official</code> agents<br> <li> Ensures correct source type is used when listing available agents


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/533/files#diff-a889c13e77d0e1263b345dfa881f0bae18375bbf30c00f51fb686ab207ca66cd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>