### PR TITLE
adding check if user can see the button to activation of the AB2

### DIFF
--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -437,11 +437,12 @@ class MultiAgentView(APIView):
                 {"error": "project is required"},
                 status=400
             )
-        
+
         try:
             project = Project.objects.get(uuid=project_uuid)
             return Response({
-                "multi_agents": project.inline_agent_switch
+                "multi_agents": project.inline_agent_switch,
+                "can_view": (("@weni.ai" in request.user.email) or ("@vtex.com" in request.user.email))
             })
         except Project.DoesNotExist:
             return Response(


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Add `can_view` field to project response for AB2 activation.

- Determine button visibility based on user email domain.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Add email-based visibility check to project API response</code>&nbsp; </dd></summary>
<hr>

nexus/inline_agents/api/views.py

<li>Add <code>can_view</code> field to API response for project.<br> <li> Set <code>can_view</code> based on user email domain (<code>@weni.ai</code> or <code>@vtex.com</code>).<br> <li> Minor formatting adjustment.


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/542/files#diff-a889c13e77d0e1263b345dfa881f0bae18375bbf30c00f51fb686ab207ca66cd">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>