### PR TITLE
adding @inspira permission on multi agent view

### DIFF
--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -442,7 +442,7 @@ class MultiAgentView(APIView):
             project = Project.objects.get(uuid=project_uuid)
             return Response({
                 "multi_agents": project.inline_agent_switch,
-                "can_view": (("@weni.ai" in request.user.email) or ("@vtex.com" in request.user.email))
+                "can_view": (("@weni.ai" in request.user.email) or ("@vtex.com" in request.user.email) or ("@inspiria.studio" in request.user.email))
             })
         except Project.DoesNotExist:
             return Response(
@@ -463,7 +463,7 @@ class MultiAgentView(APIView):
                 status=400
             )
 
-        can_access = (("@weni.ai" in request.user.email) or ("@vtex.com" in request.user.email))
+        can_access = (("@weni.ai" in request.user.email) or ("@vtex.com" in request.user.email) or ("@inspiria.studio" in request.user.email))
         if not can_access:
             return Response(
                 {"error": "You are not authorized to access this resource"},


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `@inspiria.studio` domain to permission checks

- Updated both GET and PATCH methods for multi-agent view access


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Add @inspiria.studio to multi-agent view access permissions</code></dd></summary>
<hr>

nexus/inline_agents/api/views.py

<li>Included <code>@inspiria.studio</code> in email domain checks for permissions<br> <li> Updated logic in both GET and PATCH methods to allow access for <br><code>@inspiria.studio</code> users


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/550/files#diff-a889c13e77d0e1263b345dfa881f0bae18375bbf30c00f51fb686ab207ca66cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>