### PR TITLE
Comment out task_annotations for inline agents in celery configuration

### DIFF
--- a/nexus/celery.py
+++ b/nexus/celery.py
@@ -19,9 +19,9 @@ app.conf.task_routes = {
     'router.tasks.invoke.start_inline_agents': {'queue': 'inline-agents'},
 }
 
-app.conf.task_annotations = {
-    'router.tasks.invoke.start_inline_agents': {'rate_limit': rate_limit}
-}
+# app.conf.task_annotations = {
+#     'router.tasks.invoke.start_inline_agents': {'rate_limit': rate_limit}
+# }
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Commented out `task_annotations` for inline agents in Celery config

- Disables rate limiting for `start_inline_agents` task


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>celery.py</strong><dd><code>Comment out Celery task_annotations for inline agents</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/celery.py

<li>Commented out <code>task_annotations</code> setting for <code>start_inline_agents</code><br> <li> Prevents rate limiting from being applied to this task


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/601/files#diff-cb3c41381788167110f7705d0c9b5fc994feefba461f6225da1ddd8d2c0b464c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>