### PR TITLE
adding debug to observer contact data

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -24,6 +24,7 @@ class BedrockTeamAdapter(TeamAdapter):
         contact_fields: str = ""
     ) -> dict:
         # TODO: change self to cls
+        print(f"[ + DEBUG + ] adpter_to_external contact fields: {contact_fields}")
         from nexus.usecases.intelligences.get_by_uuid import get_default_content_base_by_project
         from nexus.projects.models import Project
         content_base = get_default_content_base_by_project(project_uuid)

--- a/inline_agents/backends/bedrock/backend.py
+++ b/inline_agents/backends/bedrock/backend.py
@@ -52,7 +52,7 @@ class BedrockBackend(InlineAgentsBackend):
         turn_off_rationale: bool = False
     ):
         supervisor = self.supervisor_repository.get_supervisor(project_uuid=project_uuid)
-
+        print(f"[ + DEBUG + ] invoke_agents contact_fields: {contact_fields}")
         typing_usecase = TypingUsecase()
         if not preview:
             typing_usecase.send_typing_message(

--- a/router/tasks/invoke.py
+++ b/router/tasks/invoke.py
@@ -112,8 +112,9 @@ def start_inline_agents(
             msg_event=message.get("msg_event"),
             contact_fields=message.get("contact_fields", {}),
         )
+        print(f"[ + DEBUG + ] start_inline_agents contact_fields: {message.get('contact_fields', [])}")
 
-        print(f"[DEBUG] Message: {message}")
+        print(f"[ + DEBUG + ] Message: {message}")
 
         project = Project.objects.get(uuid=message.project_uuid)
 


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
• Add debug print statements for contact fields tracking
• Standardize debug message formatting across components
• Fix contact_fields default value inconsistency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Debugging</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Add contact fields debug logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/adapter.py

• Add debug print statement to log contact_fields parameter in <br>to_external method


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/605/files#diff-4d92e05d2b06122eea4c49b692b6c82e88c3e05995435411d94246c9fb4f4498">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend.py</strong><dd><code>Add contact fields debug logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/backend.py

• Add debug print statement to log contact_fields parameter in <br>invoke_agents method


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/605/files#diff-5c56245ed7926a9068fadb4ef081087f17d06000188307f79100a1d49355bc7a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>invoke.py</strong><dd><code>Add debug logging and fix formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

router/tasks/invoke.py

• Add debug print for contact_fields with corrected default value ([] <br>instead of {})<br> • Standardize existing debug message format


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/605/files#diff-97c35bb189d07f4b71123c64da849100810da680b81192c55fadede61785b7f2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>