### PR TITLE
adding checking for multi agents API to check the valid emails

### DIFF
--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -448,7 +448,7 @@ class MultiAgentView(APIView):
             project = Project.objects.get(uuid=project_uuid)
             return Response({
                 "multi_agents": project.inline_agent_switch,
-                "can_view": (("@weni.ai" in request.user.email) or ("@vtex.com" in request.user.email))
+                "can_view": can_view
             })
         except Project.DoesNotExist:
             return Response(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
• Replace hardcoded email domain checks with configurable setting
• Fix multi-agents API to use `MULTI_AGENTS_CAN_ACCESS` setting
• Remove hardcoded "@weni.ai" and "@vtex.com" domain validation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Replace hardcoded email validation with configurable setting</code></dd></summary>
<hr>

nexus/inline_agents/api/views.py

• Replace hardcoded email domain check with <code>can_view</code> variable<br> • Use <br>existing loop logic that checks <code>MULTI_AGENTS_CAN_ACCESS</code> setting<br> • <br>Remove direct "@weni.ai" and "@vtex.com" domain validation


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/611/files#diff-a889c13e77d0e1263b345dfa881f0bae18375bbf30c00f51fb686ab207ca66cd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>