### PR TITLE
Refactor event data handling in BedrockDataLakeEventAdapter and Summa…

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -489,11 +489,12 @@ class BedrockDataLakeEventAdapter(DataLakeEventAdapter):
         try:
             event_data["project"] = project_uuid
             event_data["contact_urn"] = contact_urn
-            self.send_data_lake_event_task.delay(event_data)
-            print(f"[ + DEBUG + ] event_data: {event_data}")
+            event_data_str = json.dumps(event_data, default=str)
+            self.send_data_lake_event_task.delay(event_data_str)
+            print(f"[ + DEBUG + ] event_data: {event_data_str}")
             return event_data
         except Exception as e:
-            logger.error(f"Error processing custom data lake event: {str(e)}")
+            logger.error(f"Error getting trace summary data lake event: {str(e)}")
             sentry_sdk.set_context("custom event to data lake", {"event_data": event_data})
             sentry_sdk.set_tag("project_uuid", project_uuid)
             sentry_sdk.capture_exception(e)

--- a/router/traces_observers/summary.py
+++ b/router/traces_observers/summary.py
@@ -127,13 +127,15 @@ class SummaryTracesObserver(EventObserver):
                 logging.warning("No trace data provided to SummaryTracesObserver")
                 return
 
+            trace_data_str = json.dumps(trace_data, default=str)
+
             if user_email and project_uuid and session_id:
                 send_preview_message_to_websocket(
                     project_uuid=str(project_uuid),
                     user_email=user_email,
                     message_data={
                         "type": "trace_update",
-                        "trace": trace_data,
+                        "trace": trace_data_str,
                         "session_id": session_id
                     }
                 )


### PR DESCRIPTION
…ryTracesObserver

- Updated BedrockDataLakeEventAdapter to serialize event_data to a JSON string before sending to the data lake.
- Modified SummaryTracesObserver to serialize trace_data to a JSON string for websocket messages.