### PR TITLE
change the name of lambda functions

### DIFF
--- a/nexus/usecases/intelligences/lambda_usecase.py
+++ b/nexus/usecases/intelligences/lambda_usecase.py
@@ -79,14 +79,15 @@ class LambdaUseCase():
         }
 
         conversation_resolution = self.invoke_lambda(
-            lambda_name="conversation-resolution",
+            lambda_name="conversation-resolution-metric",
             payload=payload_conversation
         )
+        conversation_resolution_response = conversation_resolution.get("body")
         event_data = {
             "event_name": "weni_nexus_data",
             "key": "conversation_classification",
             "value_type": "string",
-            "value": conversation_resolution.get("resolution"),
+            "value": conversation_resolution_response.get("result"),
             "metadata": {
                 "human_support": conversation.has_chats_room,
                 "conversation_id": conversation.uuid,
@@ -111,7 +112,7 @@ class LambdaUseCase():
         }
 
         conversation_topics = self.invoke_lambda(
-            lambda_name="conversation-topics",
+            lambda_name="topic_classifier_stg",
             payload=payload_topics
         )
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Lambda function names for conversation processing

- Modify response parsing for conversation resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["conversation-resolution"] --> B["conversation-resolution-metric"]
  C["conversation-topics"] --> D["topic_classifier_stg"]
  E["resolution field"] --> F["result field from body"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda_usecase.py</strong><dd><code>Update Lambda names and response parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/intelligences/lambda_usecase.py

<ul><li>Changed <code>conversation-resolution</code> Lambda name to <br><code>conversation-resolution-metric</code><br> <li> Changed <code>conversation-topics</code> Lambda name to <code>topic_classifier_stg</code><br> <li> Updated response parsing to extract <code>result</code> from <code>body</code> instead of direct <br><code>resolution</code><br> <li> Added intermediate variable <code>conversation_resolution_response</code> for <br>cleaner code</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/650/files#diff-c02de0cd7a55156df3791ec9d311d78f0a71efc1ef245f4932aa75234c238e47">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

