### PR TITLE
remove creation of conversation message

### DIFF
--- a/nexus/usecases/inline_agents/create.py
+++ b/nexus/usecases/inline_agents/create.py
@@ -103,9 +103,9 @@ class CreateConversationUseCase():
             end_date=consumer_message.get("end_date")
         )
 
-        ConversationMessage.objects.create(
-            conversation=conversation,
-            message=messages
-        )
+        # ConversationMessage.objects.create(
+        #     conversation=conversation,
+        #     message=messages
+        # )
 
         return conversation


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Comment out `ConversationMessage` object creation in conversation flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["create_conversation method"] --> B["Create conversation object"]
  B --> C["ConversationMessage creation (commented out)"]
  B --> D["Return conversation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.py</strong><dd><code>Comment out ConversationMessage object creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/inline_agents/create.py

<ul><li>Comment out <code>ConversationMessage.objects.create()</code> call<br> <li> Remove automatic message creation during conversation setup</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/657/files#diff-b5f50d433ffbfffe7a12b4bc6d0c8352a8f65b1beba41b751cc6d913366d0edb">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

