### PR TITLE
Refactor search filters in Bedrock adapters to use combined filter logic

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -184,16 +184,26 @@ class BedrockTeamAdapter(TeamAdapter):
         content_base_uuid: str
     ) -> list[dict]:
 
-        single_filter = {
-            "equals": {
-                "key": "contentBaseUuid",
-                "value": str(content_base_uuid)
-            }
+        combined_filter = {
+            "andAll": [
+                {
+                    "equals": {
+                        "key": "contentBaseUuid",
+                        "value": str(content_base_uuid)
+                    }
+                },
+                {
+                    "equals": {
+                        "key": "x-amz-bedrock-kb-data-source-id",
+                        "value": settings.AWS_BEDROCK_DATASOURCE_ID
+                    }
+                }
+            ]
         }
 
         retrieval_configuration = {
             "vectorSearchConfiguration": {
-                "filter": single_filter
+                "filter": combined_filter
             }
         }
 

--- a/nexus/task_managers/file_database/bedrock.py
+++ b/nexus/task_managers/file_database/bedrock.py
@@ -821,14 +821,26 @@ class BedrockFileDatabase(FileDataBase):
         return
 
     def search_data(self, content_base_uuid: str, text: str, number_of_results: int = 5) -> Dict[str, Any]:
-        retrieval_config = {
-            "vectorSearchConfiguration": {
-                "filter": {
+        combined_filter = {
+            "andAll": [
+                {
                     "equals": {
                         "key": "contentBaseUuid",
                         "value": content_base_uuid
                     }
                 },
+                {
+                    "equals": {
+                        "key": "x-amz-bedrock-kb-data-source-id",
+                        "value": self.data_source_id
+                    }
+                }
+            ]
+        }
+
+        retrieval_config = {
+            "vectorSearchConfiguration": {
+                "filter": combined_filter,
                 "numberOfResults": number_of_results
             }
         }


### PR DESCRIPTION
- Updated the `BedrockTeamAdapter` and `BedrockFileDatabase` classes to implement a combined filter that includes both `contentBaseUuid` and `x-amz-bedrock-kb-data-source-id`.
- This change enhances the filtering mechanism for vector search configurations.