### PR TITLE
remove comment to call topic classification lambda

### DIFF
--- a/nexus/usecases/intelligences/lambda_usecase.py
+++ b/nexus/usecases/intelligences/lambda_usecase.py
@@ -167,4 +167,4 @@ class LambdaUseCase():
         conversation = create_conversation_use_case.create_conversation(payload)
 
         self.lambda_conversation_resolution(conversation)
-        # self.lambda_conversation_topics(conversation)
+        self.lambda_conversation_topics(conversation)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enable topic classification lambda function call


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lambda Conversation Creation"] --> B["Lambda Conversation Resolution"]
  B --> C["Lambda Conversation Topics"]
  C --> D["Topic Classification Enabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda_usecase.py</strong><dd><code>Enable topic classification lambda call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/intelligences/lambda_usecase.py

<ul><li>Uncommented call to <code>lambda_conversation_topics()</code> method<br> <li> Enabled topic classification functionality in lambda conversation flow</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/678/files#diff-c02de0cd7a55156df3791ec9d311d78f0a71efc1ef245f4932aa75234c238e47">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

