### PR TITLE
Fix line endings in instruction replacement for BedrockTeamAdapter

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -277,7 +277,8 @@ class BedrockTeamAdapter(TeamAdapter):
             "{{CONTACT_NAME}}", contact_name
         ).replace(
             "{{CHANNEL_UUID}}", channel_uuid
-        )
+        ).replace("\r\n", "\n")
+
         return instruction
 
     @classmethod


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix line ending normalization in instruction replacement

- Replace Windows CRLF with Unix LF format


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Instruction Template"] --> B["Replace Variables"] --> C["Normalize Line Endings"] --> D["Return Formatted Instruction"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Normalize line endings in instruction formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/adapter.py

<ul><li>Add line ending normalization after variable replacement<br> <li> Replace Windows CRLF (\r\n) with Unix LF (\n)</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/693/files#diff-4d92e05d2b06122eea4c49b692b6c82e88c3e05995435411d94246c9fb4f4498">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

