### PR TITLE
Add channel UUID to contact information in BedrockTeamAdapter

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -81,9 +81,8 @@ class BedrockTeamAdapter(TeamAdapter):
             "inlineSessionState": self._get_inline_session_state(
                 use_components=use_components,
                 credentials=credentials,
-                contact={"urn": contact_urn, "name": contact_name},
+                contact={"urn": contact_urn, "name": contact_name, "channel_uuid": channel_uuid},
                 project={"uuid": project_uuid, "auth_token": auth_token},
-                channel={"uuid": channel_uuid},
             ),
             "enableTrace": self._get_enable_trace(),
             "sessionId": self._get_session_id(sanitized_urn, project_uuid),
@@ -127,7 +126,6 @@ class BedrockTeamAdapter(TeamAdapter):
         credentials: dict,
         contact: dict,
         project: dict,
-        channel: dict
     ) -> str:
         sessionState = {}
         session_attributes = {}
@@ -140,9 +138,6 @@ class BedrockTeamAdapter(TeamAdapter):
 
         if project:
             session_attributes["project"] = json.dumps(project, default=str)
-        
-        if channel:
-            session_attributes["channel"] = json.dumps(channel, default=str)
 
         sessionState["sessionAttributes"] = session_attributes
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Move channel UUID from separate channel object to contact information

- Simplify session state structure by removing redundant channel parameter

- Consolidate contact-related data into single object


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Channel Object"] -- "move UUID" --> B["Contact Object"]
  C["Session State"] -- "remove channel param" --> D["Simplified Structure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Consolidate channel UUID into contact information</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/adapter.py

<ul><li>Add <code>channel_uuid</code> field to contact dictionary in <code>to_external</code> method<br> <li> Remove separate <code>channel</code> parameter from <code>_get_inline_session_state</code> <br>method<br> <li> Remove channel object handling from session attributes processing<br> <li> Simplify method signature by removing unused channel parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/694/files#diff-4d92e05d2b06122eea4c49b692b6c82e88c3e05995435411d94246c9fb4f4498">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

