### PR TITLE
Feature: Update conversation on csat/nps

### DIFF
--- a/inline_agents/backends/bedrock/adapter.py
+++ b/inline_agents/backends/bedrock/adapter.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from typing import Optional
 
 import pendulum
@@ -12,7 +11,6 @@ from weni_datalake_sdk.clients.client import send_event_data
 from weni_datalake_sdk.paths.events_path import EventPath
 
 from inline_agents.adapter import TeamAdapter, DataLakeEventAdapter
-from inline_agents.backends.bedrock.prompts import PROMPT_POS_PROCESSING
 from nexus.inline_agents.models import AgentCredential, Guardrail
 
 logger = logging.getLogger(__name__)
@@ -458,8 +456,10 @@ class BedrockDataLakeEventAdapter(DataLakeEventAdapter):
         inline_trace: dict,
         project_uuid: str,
         contact_urn: str,
+        channel_uuid: str,
         preview: bool = False
     ):
+        from nexus.intelligences.models import Conversation
         if preview:
             return None
 
@@ -481,8 +481,14 @@ class BedrockDataLakeEventAdapter(DataLakeEventAdapter):
                     event_to_send["metadata"] = {}
                 if event_to_send.get("key") == "weni_csat":
                     event_to_send["metadata"]["agent_uuid"] = settings.AGENT_UUID_CSAT
+                    conversation = Conversation.objects.get(project__uuid=project_uuid, contact_urn=contact_urn, channel_uuid=channel_uuid)
+                    conversation.csat = event_to_send.get("value")
+                    conversation.save()
                 if event_to_send.get("key") == "weni_nps":
                     event_to_send["metadata"]["agent_uuid"] = settings.AGENT_UUID_NPS
+                    conversation = Conversation.objects.get(project__uuid=project_uuid, contact_urn=contact_urn, channel_uuid=channel_uuid)
+                    conversation.nps = event_to_send.get("value")
+                    conversation.save()
 
                 self.to_data_lake_custom_event(
                     event_data=event_to_send,

--- a/inline_agents/backends/bedrock/backend.py
+++ b/inline_agents/backends/bedrock/backend.py
@@ -174,6 +174,7 @@ class BedrockBackend(InlineAgentsBackend):
                     inline_trace=trace_data,
                     project_uuid=project_uuid,
                     contact_urn=contact_urn,
+                    channel_uuid=channel_uuid,
                     preview=preview
                 )
 

--- a/inline_agents/backends/bedrock/tests/traces_factory.py
+++ b/inline_agents/backends/bedrock/tests/traces_factory.py
@@ -3,6 +3,7 @@ import uuid
 import random
 from faker import Faker
 import pendulum
+import json
 
 faker = Faker()
 
@@ -117,6 +118,90 @@ class CustomEventTraceFactory(factory.Factory):
                                     }
                                 ]
                             }"""
+                        },
+                        "traceId": str(uuid.uuid4()),
+                        "type": "ACTION_GROUP"
+                    }
+                }
+            }
+        }
+
+
+class CSATEventTraceFactory(factory.Factory):
+    class Meta:
+        model = dict
+
+    csat_value = factory.Iterator(['1', '2', '3', '4', '5'])
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        return {
+            "collaboratorName": "csat_agent",
+            "eventTime": pendulum.now().to_iso8601_string(),
+            "sessionId": str(uuid.uuid4()),
+            "trace": {
+                "orchestrationTrace": {
+                    "observation": {
+                        "actionGroupInvocationOutput": {
+                            "metadata": {
+                                "clientRequestId": str(uuid.uuid4()),
+                                "endTime": pendulum.now().to_iso8601_string(),
+                                "startTime": pendulum.now().to_iso8601_string(),
+                                "totalTimeMs": random.randint(0, 10000)
+                            },
+                            "text": json.dumps({
+                                "events": [
+                                    {
+                                        "event_name": "weni_nexus_data",
+                                        "key": "weni_csat",
+                                        "value_type": "string",
+                                        "value": kwargs.get('csat_value', cls.csat_value),
+                                        "metadata": {}
+                                    }
+                                ]
+                            })
+                        },
+                        "traceId": str(uuid.uuid4()),
+                        "type": "ACTION_GROUP"
+                    }
+                }
+            }
+        }
+
+
+class NPSEventTraceFactory(factory.Factory):
+    class Meta:
+        model = dict
+
+    nps_value = factory.Iterator([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        return {
+            "collaboratorName": "nps_agent",
+            "eventTime": pendulum.now().to_iso8601_string(),
+            "sessionId": str(uuid.uuid4()),
+            "trace": {
+                "orchestrationTrace": {
+                    "observation": {
+                        "actionGroupInvocationOutput": {
+                            "metadata": {
+                                "clientRequestId": str(uuid.uuid4()),
+                                "endTime": pendulum.now().to_iso8601_string(),
+                                "startTime": pendulum.now().to_iso8601_string(),
+                                "totalTimeMs": random.randint(0, 10000)
+                            },
+                            "text": json.dumps({
+                                "events": [
+                                    {
+                                        "event_name": "weni_nexus_data",
+                                        "key": "weni_nps",
+                                        "value_type": "string",
+                                        "value": kwargs.get('nps_value', cls.nps_value),
+                                        "metadata": {}
+                                    }
+                                ]
+                            })
                         },
                         "traceId": str(uuid.uuid4()),
                         "type": "ACTION_GROUP"

--- a/nexus/intelligences/models.py
+++ b/nexus/intelligences/models.py
@@ -12,7 +12,6 @@ from nexus.projects.models import Project
 from nexus.inline_agents.models import InlineAgentMessage
 
 
-
 class Intelligence(BaseModel, SoftDeleteModel):
     name = models.CharField(max_length=255)
     content_bases_count = models.PositiveBigIntegerField(default=0)

--- a/nexus/usecases/intelligences/lambda_usecase.py
+++ b/nexus/usecases/intelligences/lambda_usecase.py
@@ -142,7 +142,7 @@ class LambdaUseCase():
             )
             conversation_topics = json.loads(conversation_topics.get("Payload").read())
             conversation_topics = conversation_topics.get("body")
-            print("Conversation topic resuts: ", conversation_topics)
+
             if conversation_topics.get("topic_uuid") != "":
                 event_data = {
                     "event_name": "weni_nexus_data",

--- a/nexus/usecases/intelligences/tests/intelligence_factory.py
+++ b/nexus/usecases/intelligences/tests/intelligence_factory.py
@@ -192,6 +192,7 @@ class ConversationFactory(factory.django.DjangoModelFactory):
     start_date = factory.Faker('date_time_between', start_date='-30d', end_date='now', tzinfo=timezone.utc)
     end_date = factory.Faker('date_time_between', start_date='-1d', end_date='now', tzinfo=timezone.utc)
     has_chats_room = factory.Faker('boolean')
+    channel_uuid = factory.Faker('uuid4')
     csat = factory.Faker('random_element', elements=Conversation.CSAT_CHOICES)
     resolution = factory.Faker('random_element', elements=Conversation.RESOLUTION_CHOICES)
     topic = factory.SubFactory(TopicsFactory)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add CSAT/NPS conversation field updates when events are processed

- Include channel_uuid parameter in custom event data methods

- Add comprehensive test coverage for CSAT/NPS functionality

- Remove unused imports and fix minor formatting issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bedrock Backend"] --> B["Custom Event Data"]
  B --> C["CSAT Event"]
  B --> D["NPS Event"]
  C --> E["Update Conversation.csat"]
  D --> F["Update Conversation.nps"]
  E --> G["Data Lake Event"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Add conversation field updates for CSAT/NPS events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/adapter.py

<ul><li>Add channel_uuid parameter to custom_event_data method<br> <li> Import Conversation model and update csat/nps fields when processing <br>events<br> <li> Remove unused imports (os, PROMPT_POS_PROCESSING)</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-4d92e05d2b06122eea4c49b692b6c82e88c3e05995435411d94246c9fb4f4498">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend.py</strong><dd><code>Include channel UUID in event data processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/backend.py

- Pass channel_uuid parameter to custom_event_data method call


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-5c56245ed7926a9068fadb4ef081087f17d06000188307f79100a1d49355bc7a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_adapter.py</strong><dd><code>Add comprehensive CSAT/NPS testing coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/tests/test_adapter.py

<ul><li>Add comprehensive test cases for CSAT and NPS event processing<br> <li> Import new trace factories and ConversationFactory<br> <li> Update existing tests to include channel_uuid parameter<br> <li> Test conversation model updates and preview mode behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-fc5be9b8b5301e8e999bf8e335f7f81ef89ce5eebe4250d6834f6e3e33062ba7">+136/-7</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>traces_factory.py</strong><dd><code>Add CSAT and NPS trace factories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/bedrock/tests/traces_factory.py

<ul><li>Add CSATEventTraceFactory for generating CSAT test traces<br> <li> Add NPSEventTraceFactory for generating NPS test traces<br> <li> Import json module for proper event data formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-3c86ed40df214d3cdecf160748561dd173a6971c4a4ba919d8d7fcbe4538a713">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>intelligence_factory.py</strong><dd><code>Add channel UUID to conversation factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/intelligences/tests/intelligence_factory.py

- Add channel_uuid field to ConversationFactory


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-99466ba54ccdbff65f7624791113d4423c8cc6e6edfdf36019b7df6d2d3265bd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Minor formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/intelligences/models.py

- Remove extra blank line for code formatting


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-0f654d50e63f0c889dfb5b48f41ecd95d8c422379568c5b0176c889dc6b5adfb">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda_usecase.py</strong><dd><code>Remove debug print statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/intelligences/lambda_usecase.py

- Remove debug print statement


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/707/files#diff-c02de0cd7a55156df3791ec9d311d78f0a71efc1ef245f4932aa75234c238e47">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

