### PR TITLE
Fix resolution mapping

### DIFF
--- a/nexus/usecases/intelligences/lambda_usecase.py
+++ b/nexus/usecases/intelligences/lambda_usecase.py
@@ -179,6 +179,15 @@ class LambdaUseCase():
             self.task_manager = RedisTaskManager()
         return self.task_manager
 
+    def _convert_resolution_to_choice_value(self, resolution_string: str) -> str:
+
+        resolution_mapping = {
+            "resolved": "0",
+            "unresolved": "1",
+            "in progress": "2"
+        }
+        return resolution_mapping.get(resolution_string.lower(), "2")  # Default to "2" (In Progress)
+
 
 @celery_app.task
 def create_lambda_conversation(
@@ -223,6 +232,8 @@ def create_lambda_conversation(
         contact_urn=payload.get("contact_urn")
     )
 
+    resolution_choice_value = lambda_usecase._convert_resolution_to_choice_value(resolution)
+
     update_data = {
         "start_date": payload.get("start_date"),
         "end_date": payload.get("end_date"),
@@ -230,7 +241,7 @@ def create_lambda_conversation(
         "contact_name": payload.get("name"),
         "contact_urn": payload.get("contact_urn"),
         "external_id": payload.get("external_id"),
-        "resolution": resolution,
+        "resolution": resolution_choice_value,
         "topic": topic
     }
 

--- a/router/tasks/invoke.py
+++ b/router/tasks/invoke.py
@@ -259,6 +259,8 @@ def start_inline_agents(
         sentry_sdk.set_context("message", {
             "project_uuid": message.get("project_uuid"),
             "contact_urn": message.get("contact_urn"),
+            "channel_uuid": message.get("channel_uuid"),
+            "contact_name": message.get("contact_name"),
             "text": message.get("text", ""),
             "preview": preview,
             "language": language,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix resolution mapping to use choice values

- Add Sentry context fields for debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Resolution String"] --> B["Convert to Choice Value"]
  B --> C["Update Conversation"]
  D["Error Context"] --> E["Enhanced Sentry Logging"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda_usecase.py</strong><dd><code>Add resolution string to choice value conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/intelligences/lambda_usecase.py

<ul><li>Add <code>_convert_resolution_to_choice_value</code> method to map resolution <br>strings to numeric choice values<br> <li> Update conversation resolution field to use converted choice value <br>instead of raw string</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/720/files#diff-c02de0cd7a55156df3791ec9d311d78f0a71efc1ef245f4932aa75234c238e47">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invoke.py</strong><dd><code>Enhance Sentry error context with additional fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

router/tasks/invoke.py

<ul><li>Add <code>channel_uuid</code> and <code>contact_name</code> fields to Sentry error context</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/720/files#diff-97c35bb189d07f4b71123c64da849100810da680b81192c55fadede61785b7f2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

