### PR TITLE
Add messageVersion to payload in OpenAITeamAdapter for versioning sup…

### DIFF
--- a/inline_agents/backends/openai/adapter.py
+++ b/inline_agents/backends/openai/adapter.py
@@ -194,6 +194,7 @@ class OpenAITeamAdapter(TeamAdapter):
                 },
                 "actionGroup": function_name,
                 "function": function_arn,
+                "messageVersion": "1.0",
             }
 
             payload_json = json.dumps(payload_json)


### PR DESCRIPTION
### **User description**
…port


___

### **PR Type**
Enhancement


___

### **Description**
- Add `messageVersion` field to AWS Lambda payload

- Support versioning in OpenAI team adapter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OpenAI Team Adapter"] --> B["AWS Lambda Payload"] 
  B --> C["messageVersion: 1.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>adapter.py</strong><dd><code>Add messageVersion field to Lambda payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inline_agents/backends/openai/adapter.py

- Add `messageVersion` field with value "1.0" to AWS Lambda payload


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/729/files#diff-d2da8182d1eebc4e2c53bcbf3c277a359b6c0450c1a3edde6db12975366455dd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

