### PR TITLE
Remove foundation model assignment from UpdateAgentUseCase

### DIFF
--- a/nexus/usecases/inline_agents/update.py
+++ b/nexus/usecases/inline_agents/update.py
@@ -29,7 +29,6 @@ class UpdateAgentUseCase(ToolsUseCase, InstructionsUseCase):
         agent_obj.name = agent_data["name"]
         agent_obj.collaboration_instructions = agent_data["description"]
         agent_obj.instruction = instructions
-        agent_obj.foundation_model = settings.AWS_BEDROCK_AGENTS_MODEL_ID[0]
         agent_obj.save()
 
         self.handle_tools(agent_obj, project, agent_data["tools"], files, str(project.uuid))


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove hardcoded foundation model assignment from agent updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UpdateAgentUseCase"] --> B["Agent Object Update"]
  B --> C["Remove Foundation Model Assignment"]
  C --> D["Save Agent"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update.py</strong><dd><code>Remove foundation model hardcoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/inline_agents/update.py

<ul><li>Removed hardcoded foundation model assignment line<br> <li> Simplified agent update process by removing AWS Bedrock model <br>dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/732/files#diff-aaefee2a790026f070281136b4b7852639956d04d7e10855d3bceb1534752d26">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

