### PR TITLE
Fix empty msgs

### DIFF
--- a/router/clients/flows/http/send_message.py
+++ b/router/clients/flows/http/send_message.py
@@ -113,6 +113,9 @@ class WhatsAppBroadcastHTTPClient(DirectMessage):
         full_chunks: List[Dict] = None
     ) -> None:
         msgs = self.get_json_strings(msg)
+        if not msgs:
+            msgs = [{"msg": {"text": str(msg)}}]
+
         for msg in msgs:
             response = FlowsRESTClient().whatsapp_broadcast(urns, msg, project_uuid)
             try:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add fallback handling for empty message lists

- Convert message to string format when no JSON strings available


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_json_strings(msg)"] --> B{"msgs empty?"}
  B -->|Yes| C["Create fallback msg with text"]
  B -->|No| D["Use existing msgs"]
  C --> E["Send messages via WhatsApp broadcast"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>send_message.py</strong><dd><code>Add empty message fallback handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

router/clients/flows/http/send_message.py

<ul><li>Add empty message list check after <code>get_json_strings()</code><br> <li> Create fallback message with string conversion when msgs is empty<br> <li> Ensure message sending continues with valid data structure</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/749/files#diff-26ac23dd5fc05af4dd48b29245f30bbed1f8a5ea152716d1c317225cac94f7b1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

