### PR TITLE
fix conversation filter

### DIFF
--- a/nexus/usecases/intelligences/create.py
+++ b/nexus/usecases/intelligences/create.py
@@ -333,7 +333,7 @@ class ConversationUseCase():
 
         if conversation.count() > 1:
             conversation = conversation.order_by('-created_at')
-            conversation.exclude(id=conversation.first().id).update(resolution=3)
+            conversation.exclude(uuid=conversation.first().uuid).update(resolution=3)
 
             return True
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix conversation filtering to use UUID instead of ID


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Conversation Query"] --> B["Filter by UUID"] 
  B --> C["Update Resolution Status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.py</strong><dd><code>Fix conversation filter field reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/usecases/intelligences/create.py

<ul><li>Changed conversation exclusion filter from <code>id</code> to <code>uuid</code> field<br> <li> Fixed filtering logic in <code>conversation_in_progress_exists</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/766/files#diff-36a148f494920166390e35cf2f6ce7d04ff45ee41616e0a004ab07d78240febd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

