### PR TITLE
Fix websocket consumer close logic to prevent further execution after…

### DIFF
--- a/nexus/projects/websockets/consumers.py
+++ b/nexus/projects/websockets/consumers.py
@@ -66,6 +66,7 @@ class WebsocketMessageConsumer(WebsocketConsumer):
 
         if self.user.is_anonymous or close is True or self.project is None:
             self.close()
+            return
 
         if not has_project_permission(
             self.user,
@@ -73,6 +74,7 @@ class WebsocketMessageConsumer(WebsocketConsumer):
             "GET"
         ):
             self.close()
+            return
 
         async_to_sync(self.channel_layer.group_add)(
             self.room_group_name,


### PR DESCRIPTION
### **User description**
… closing


___

### **PR Type**
Bug fix


___

### **Description**
- Add return statements after websocket close calls

- Prevent further execution after connection rejection

- Fix anonymous user and permission handling flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocket Connect"] --> B["Check Project Exists"]
  B --> C["Check User & Permissions"]
  C --> D["Close Connection"]
  D --> E["Return Early"]
  E --> F["Stop Further Execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consumers.py</strong><dd><code>Add return statements after websocket close</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nexus/projects/websockets/consumers.py

<ul><li>Add <code>return</code> statements after <code>self.close()</code> calls<br> <li> Prevent execution of subsequent code after connection closure<br> <li> Fix control flow for anonymous users and permission failures</ul>


</details>


  </td>
  <td><a href="https://github.com/weni-ai/nexus-ai/pull/794/files#diff-594d654fc07db96f5ccddcfeafaaad6581ec21dd46ae3b710b525079db436f21">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

