### PR TITLE
Enhance preview handling in start_inline_agents and _run_post_generation functions

### DIFF
--- a/router/tasks/invoke.py
+++ b/router/tasks/invoke.py
@@ -698,12 +698,19 @@ def start_inline_agents(  # noqa: C901
             turn_id=turn_id,
         )
 
+        if skip_dispatch:
+            _invoke_is_final_debug("H start_inline_agents branch=skip_dispatch (no dispatch)")
+            if preview or preview_websocket:
+                ws_content = {"type": "broadcast", "message": response, "fonts": []}
+                send_preview_message_to_websocket(
+                    project_uuid=message_obj.project_uuid,
+                    user_email=user_email,
+                    message_data={"type": "preview", "content": ws_content},
+                )
+            return True
         if preview or preview_websocket:
             _invoke_is_final_debug("H start_inline_agents branch=dispatch_preview")
             return dispatch_preview(response, message_obj, broadcast, user_email, agents_backend, flows_user_email)
-        if skip_dispatch:
-            _invoke_is_final_debug("H start_inline_agents branch=skip_dispatch (no dispatch)")
-            return True
         _invoke_is_final_debug("H start_inline_agents branch=dispatch")
         return dispatch(
             llm_response=response,

--- a/router/tasks/workflow_orchestrator.py
+++ b/router/tasks/workflow_orchestrator.py
@@ -377,6 +377,16 @@ def _run_post_generation(ctx: WorkflowContext, response: str, skip_dispatch: boo
     )
 
     # Dispatch response
+    if skip_dispatch:
+        _invoke_is_final_debug("H workflow post_generation branch=skip_dispatch (no dispatch)")
+        if ctx.preview or ctx.preview_websocket:
+            ws_content = {"type": "broadcast", "message": response, "fonts": []}
+            send_preview_message_to_websocket(
+                project_uuid=message_obj.project_uuid,
+                user_email=ctx.user_email,
+                message_data={"type": "preview", "content": ws_content},
+            )
+        return True
     if ctx.preview or ctx.preview_websocket:
         _invoke_is_final_debug("H workflow post_generation branch=dispatch_preview")
         return dispatch_preview(
@@ -387,9 +397,6 @@ def _run_post_generation(ctx: WorkflowContext, response: str, skip_dispatch: boo
             ctx.agents_backend,
             ctx.flows_user_email,
         )
-    if skip_dispatch:
-        _invoke_is_final_debug("H workflow post_generation branch=skip_dispatch (no dispatch)")
-        return True
     _invoke_is_final_debug("H workflow post_generation branch=dispatch")
     return dispatch(
         llm_response=response,


### PR DESCRIPTION
- Added logic to send preview messages to WebSocket when skip_dispatch is true in both start_inline_agents and _run_post_generation.
- Reorganized the flow to ensure that preview handling is consistent across both functions, improving the clarity and maintainability of the code.