### PR TITLE
feat(api): enhance date parameter handling in SupervisorPublicConvers…

### DIFF
--- a/nexus/intelligences/api/supervisor_public.py
+++ b/nexus/intelligences/api/supervisor_public.py
@@ -505,10 +505,19 @@ class SupervisorPublicConversationsViewV2(APIView):
             "previous": self._rewrite_pagination_url(previous_url, request) if previous_url else None,
         }
 
+    @staticmethod
+    def _get_v2_date_bounds(request):
+        """
+        Public API uses start/end; cursor next links from nexus-conversations use start_date/end_date.
+        Prefer start/end when both are present.
+        """
+        start = request.query_params.get("start") or request.query_params.get("start_date")
+        end = request.query_params.get("end") or request.query_params.get("end_date")
+        return start, end
+
     def _parse_request_params(self, request):
         """Parse and validate query params for nexus-conversations API. Raises ValidationError on invalid input."""
-        start = request.query_params.get("start")
-        end = request.query_params.get("end")
+        start, end = self._get_v2_date_bounds(request)
         _validate_supervisor_public_v2_query_dates(start, end)
 
         params = {}
@@ -534,6 +543,15 @@ class SupervisorPublicConversationsViewV2(APIView):
         params["page_size"] = page_size
         return params, page_size
 
+    @staticmethod
+    def _normalize_public_v2_pagination_query(query_params):
+        """Map upstream start_date/end_date to public start/end in cursor links."""
+        if "start_date" in query_params and "start" not in query_params:
+            query_params["start"] = query_params.pop("start_date")
+        if "end_date" in query_params and "end" not in query_params:
+            query_params["end"] = query_params.pop("end_date")
+        return query_params
+
     def _rewrite_pagination_url(self, url, request):
         """Rewrite pagination URL to point to nexus-ai v2 endpoint."""
         if not url:
@@ -544,6 +562,7 @@ class SupervisorPublicConversationsViewV2(APIView):
             if not query_params:
                 return request.build_absolute_uri(request.path)
 
+            query_params = self._normalize_public_v2_pagination_query(query_params)
             base_url = request.build_absolute_uri(request.path)
             query_string = urlencode(query_params, doseq=True)
             parsed_base = urlparse(base_url)

--- a/nexus/intelligences/api/tests/test_supervisor_public.py
+++ b/nexus/intelligences/api/tests/test_supervisor_public.py
@@ -453,3 +453,31 @@ class TestSupervisorPublicAPI(TestCase):
         self.assertEqual(upstream_params["end_date"], "2026-04-20T23:59:59Z")
         self.assertEqual(upstream_params["status"], "1")
         self.assertEqual(upstream_params["cursor"], "opaque-token")
+
+    @mock.patch.object(SupervisorPublicConversationsViewV2, "_fetch_conversation_messages")
+    @mock.patch.object(SupervisorPublicConversationsViewV2, "_call_conversations_api")
+    def test_v2_start_end_take_precedence_over_start_date_end_date(self, mock_call, mock_fetch_messages):
+        mock_fetch_messages.return_value = []
+        mock_call.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "total_count": 1,
+            "status_summary": {"0": 0, "1": 1, "2": 0, "3": 0, "4": 0},
+        }
+
+        url = reverse(
+            "public-supervisor-conversations-v2",
+            kwargs={"project_uuid": str(self.project.uuid)},
+        )
+        response = self.client.get(
+            f"{url}?start=2026-04-10T00:00:00Z&end=2026-04-15T23:59:59Z"
+            f"&start_date=2026-04-01T00:00:00Z&end_date=2026-04-20T23:59:59Z&status=1",
+            HTTP_AUTHORIZATION=f"ApiKey {self.raw_token}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_call.assert_called_once()
+        upstream_params = mock_call.call_args[0][1]
+        self.assertEqual(upstream_params["start_date"], "2026-04-10T00:00:00Z")
+        self.assertEqual(upstream_params["end_date"], "2026-04-15T23:59:59Z")

--- a/nexus/intelligences/api/tests/test_supervisor_public.py
+++ b/nexus/intelligences/api/tests/test_supervisor_public.py
@@ -390,3 +390,66 @@ class TestSupervisorPublicAPI(TestCase):
         next_link = response.json()["next"]
         self.assertIn("cursor=opaque-token", next_link)
         self.assertIn(f"/public/v2/{self.project.uuid}/supervisor/conversations", next_link)
+
+    @mock.patch.object(SupervisorPublicConversationsViewV2, "_fetch_conversation_messages")
+    @mock.patch.object(SupervisorPublicConversationsViewV2, "_call_conversations_api")
+    def test_v2_next_link_uses_public_start_end_param_names(self, mock_call, mock_fetch_messages):
+        mock_fetch_messages.return_value = []
+        mock_call.return_value = {
+            "results": [],
+            "next": (
+                f"https://conversations.internal/api/v1/projects/{self.project.uuid}/conversations/"
+                f"?cursor=opaque-token&page_size=50"
+                f"&start_date=2026-04-01T00%3A00%3A00Z&end_date=2026-04-20T23%3A59%3A59Z&status=1"
+            ),
+            "previous": None,
+            "total_count": 501,
+            "status_summary": {"0": 0, "1": 501, "2": 0, "3": 0, "4": 0},
+        }
+
+        url = reverse(
+            "public-supervisor-conversations-v2",
+            kwargs={"project_uuid": str(self.project.uuid)},
+        )
+        response = self.client.get(
+            f"{url}?start=2026-04-01T00:00:00Z&end=2026-04-20T23:59:59Z&status=1",
+            HTTP_AUTHORIZATION=f"ApiKey {self.raw_token}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        next_link = response.json()["next"]
+        self.assertIn("start=2026-04-01T00%3A00%3A00Z", next_link)
+        self.assertIn("end=2026-04-20T23%3A59%3A59Z", next_link)
+        self.assertNotIn("start_date=", next_link)
+        self.assertNotIn("end_date=", next_link)
+
+    @mock.patch.object(SupervisorPublicConversationsViewV2, "_fetch_conversation_messages")
+    @mock.patch.object(SupervisorPublicConversationsViewV2, "_call_conversations_api")
+    def test_v2_cursor_request_with_start_date_end_date_forwards_date_filters(self, mock_call, mock_fetch_messages):
+        mock_fetch_messages.return_value = []
+        mock_call.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "total_count": 501,
+            "status_summary": {"0": 0, "1": 501, "2": 0, "3": 0, "4": 0},
+        }
+
+        url = reverse(
+            "public-supervisor-conversations-v2",
+            kwargs={"project_uuid": str(self.project.uuid)},
+        )
+        response = self.client.get(
+            f"{url}?cursor=opaque-token&page_size=50"
+            f"&start_date=2026-04-01T00:00:00Z&end_date=2026-04-20T23:59:59Z&status=1",
+            HTTP_AUTHORIZATION=f"ApiKey {self.raw_token}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 501)
+        mock_call.assert_called_once()
+        upstream_params = mock_call.call_args[0][1]
+        self.assertEqual(upstream_params["start_date"], "2026-04-01T00:00:00Z")
+        self.assertEqual(upstream_params["end_date"], "2026-04-20T23:59:59Z")
+        self.assertEqual(upstream_params["status"], "1")
+        self.assertEqual(upstream_params["cursor"], "opaque-token")


### PR DESCRIPTION
…ationsViewV2

- Introduced _get_v2_date_bounds method to prioritize 'start' and 'end' over 'start_date' and 'end_date' in query parameters.
- Added _normalize_public_v2_pagination_query method to map 'start_date' and 'end_date' to 'start' and 'end' for pagination links.
- Updated _rewrite_pagination_url to utilize the new normalization method.
- Added tests to verify correct handling of date parameters in API responses.