### PR TITLE
feat: add CSV export functionality for conversations

### DIFF
--- a/nexus/internals/conversations.py
+++ b/nexus/internals/conversations.py
@@ -13,7 +13,7 @@ class ConversationsRESTClient(RestClient):
 
     def _get_url(self, endpoint: str) -> str:
         assert endpoint.startswith("/"), "the endpoint needs to start with: /"
-        return self.base_url + endpoint
+        return self.base_url.rstrip("/") + endpoint
 
     @property
     def headers(self):

--- a/nexus/internals/conversations.py
+++ b/nexus/internals/conversations.py
@@ -108,3 +108,20 @@ class ConversationsRESTClient(RestClient):
             url = urljoin(self.base_url, next_url) if next_url else None
 
         return all_results
+
+    def export_conversations_csv(self, project_uuid: str, target_date: str | None = None):
+        """
+        POST export endpoint; returns the raw requests.Response (CSV body + headers).
+        """
+        endpoint = f"/api/v1/projects/{project_uuid}/conversations/export/"
+        payload = {}
+        if target_date is not None:
+            payload["target_date"] = target_date
+        response = requests.post(
+            self._get_url(endpoint),
+            headers={**self.headers, "Content-Type": "application/json"},
+            json=payload,
+            timeout=120,
+        )
+        response.raise_for_status()
+        return response

--- a/nexus/projects/api/routers.py
+++ b/nexus/projects/api/routers.py
@@ -4,6 +4,7 @@ from .views import (
     AgentBuilderProjectDetailsView,
     AgentsBackendView,
     ConversationDetailProxyView,
+    ConversationsExportProxyView,
     ConversationsProxyView,
     EnableHumanSupportView,
     ProjectPromptCreationConfigurationsViewset,
@@ -21,6 +22,11 @@ urlpatterns = [
     path("<project_uuid>/human-support", EnableHumanSupportView.as_view(), name="enable-human-support"),
     path("<project_uuid>/ab-project-details", AgentBuilderProjectDetailsView.as_view(), name="ab-project-details"),
     path("v2/<project_uuid>/conversations", ConversationsProxyView.as_view(), name="conversations-proxy-v2"),
+    path(
+        "v2/<project_uuid>/conversations/export",
+        ConversationsExportProxyView.as_view(),
+        name="conversations-export-proxy-v2",
+    ),
     path(
         "v2/<project_uuid>/conversations/<conversation_uuid>",
         ConversationDetailProxyView.as_view(),

--- a/nexus/projects/api/tests/test_conversations_proxy_permissions.py
+++ b/nexus/projects/api/tests/test_conversations_proxy_permissions.py
@@ -7,7 +7,11 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from nexus.projects.api.views import ConversationDetailProxyView, ConversationsProxyView
+from nexus.projects.api.views import (
+    ConversationDetailProxyView,
+    ConversationsExportProxyView,
+    ConversationsProxyView,
+)
 from nexus.projects.models import Project
 from nexus.projects.permissions import has_project_permission
 from nexus.usecases.intelligences.tests.intelligence_factory import IntegratedIntelligenceFactory
@@ -173,3 +177,61 @@ class TestConversationDetailProxyViewPermissions(_PermissionTestBase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         mock_get.assert_not_called()
+
+
+def _build_csv_export_response(content=b"conversation_uuid\n", day="2026-05-13", row_count=1):
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.content = content
+    resp.headers = {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": f'attachment; filename="conversations_{day}.csv"',
+        "X-Export-Row-Count": str(row_count),
+        "X-Export-Target-Date": day,
+    }
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@mock.patch("nexus.projects.api.views.requests.post")
+class TestConversationsExportProxyViewPermissions(_PermissionTestBase):
+    def setUp(self):
+        super().setUp()
+        self.view = ConversationsExportProxyView.as_view()
+        self.url = f"/api/v2/{self.project_uuid}/conversations/export"
+
+    def test_project_permission_grants_access(self, mock_post):
+        mock_post.return_value = _build_csv_export_response()
+
+        request = self.factory.post(self.url, {"target_date": "2026-05-13"}, format="json")
+        force_authenticate(request, user=self.authorized_user)
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
+        mock_post.assert_called_once()
+
+    def test_internal_permission_grants_access_when_project_denied(self, mock_post):
+        mock_post.return_value = _build_csv_export_response()
+
+        request = self.factory.post(self.url, {}, format="json")
+        force_authenticate(request, user=self.internal_user)
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_post.assert_called_once()
+
+    def test_no_permission_returns_403(self, mock_post):
+        request = self.factory.post(self.url, {}, format="json")
+        force_authenticate(request, user=self.unauthorized_user)
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_post.assert_not_called()
+
+    def test_unauthenticated_returns_401(self, mock_post):
+        request = self.factory.post(self.url, {}, format="json")
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        mock_post.assert_not_called()

--- a/nexus/projects/api/tests/test_conversations_proxy_permissions.py
+++ b/nexus/projects/api/tests/test_conversations_proxy_permissions.py
@@ -193,15 +193,15 @@ def _build_csv_export_response(content=b"conversation_uuid\n", day="2026-05-13",
     return resp
 
 
-@mock.patch("nexus.projects.api.views.requests.post")
+@mock.patch("nexus.internals.conversations.ConversationsRESTClient.export_conversations_csv")
 class TestConversationsExportProxyViewPermissions(_PermissionTestBase):
     def setUp(self):
         super().setUp()
         self.view = ConversationsExportProxyView.as_view()
         self.url = f"/api/v2/{self.project_uuid}/conversations/export"
 
-    def test_project_permission_grants_access(self, mock_post):
-        mock_post.return_value = _build_csv_export_response()
+    def test_project_permission_grants_access(self, mock_export):
+        mock_export.return_value = _build_csv_export_response()
 
         request = self.factory.post(self.url, {"target_date": "2026-05-13"}, format="json")
         force_authenticate(request, user=self.authorized_user)
@@ -209,29 +209,29 @@ class TestConversationsExportProxyViewPermissions(_PermissionTestBase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
-        mock_post.assert_called_once()
+        mock_export.assert_called_once_with(self.project_uuid, target_date="2026-05-13")
 
-    def test_internal_permission_grants_access_when_project_denied(self, mock_post):
-        mock_post.return_value = _build_csv_export_response()
+    def test_internal_permission_grants_access_when_project_denied(self, mock_export):
+        mock_export.return_value = _build_csv_export_response()
 
         request = self.factory.post(self.url, {}, format="json")
         force_authenticate(request, user=self.internal_user)
         response = self.view(request, project_uuid=self.project_uuid)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_post.assert_called_once()
+        mock_export.assert_called_once_with(self.project_uuid, target_date=None)
 
-    def test_no_permission_returns_403(self, mock_post):
+    def test_no_permission_returns_403(self, mock_export):
         request = self.factory.post(self.url, {}, format="json")
         force_authenticate(request, user=self.unauthorized_user)
         response = self.view(request, project_uuid=self.project_uuid)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        mock_post.assert_not_called()
+        mock_export.assert_not_called()
 
-    def test_unauthenticated_returns_401(self, mock_post):
+    def test_unauthenticated_returns_401(self, mock_export):
         request = self.factory.post(self.url, {}, format="json")
         response = self.view(request, project_uuid=self.project_uuid)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        mock_post.assert_not_called()
+        mock_export.assert_not_called()

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import requests
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.http import HttpResponse
 from rest_framework import serializers, status, views
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -350,6 +351,92 @@ class ConversationsProxyView(APIView):
         error_message = str(e)
         logger.error(f"Error fetching conversations for project {project_uuid}: {error_message}", exc_info=True)
         self.usecase.send_to_sentry(project_uuid, None, error_message, None, exception=e)
+        return Response({"error": "Internal server error"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class ConversationsExportProxyView(APIView):
+    permission_classes = [IsAuthenticated, ProjectPermission | InternalCommunicationPermission]
+
+    def post(self, request, *args, **kwargs):
+        """
+        Proxy endpoint to export conversations CSV from the Conversations service.
+        Authenticated users need project permission; the upstream call uses CONVERSATIONS_TOKEN.
+        """
+        project_uuid = kwargs.get("project_uuid")
+        if not project_uuid:
+            return Response({"error": "project_uuid is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        payload = {}
+        target_date = request.data.get("target_date")
+        if target_date is not None:
+            payload["target_date"] = target_date
+
+        try:
+            upstream = self._call_conversations_export(project_uuid, payload)
+            return self._build_csv_response(upstream)
+        except requests.exceptions.HTTPError as e:
+            return self._handle_http_error(e, project_uuid)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RequestException,
+            Exception,
+        ) as e:
+            return self._handle_generic_error(e, project_uuid)
+
+    def _call_conversations_export(self, project_uuid, payload):
+        base_url = settings.CONVERSATIONS_REST_ENDPOINT.rstrip("/")
+        endpoint = f"/api/v1/projects/{project_uuid}/conversations/export/"
+        url = base_url + endpoint
+        headers = {
+            "Authorization": f"Bearer {settings.CONVERSATIONS_TOKEN}",
+            "Content-Type": "application/json",
+        }
+        response = requests.post(url, headers=headers, json=payload, timeout=120)
+        response.raise_for_status()
+        return response
+
+    def _build_csv_response(self, upstream):
+        response = HttpResponse(
+            upstream.content,
+            content_type=upstream.headers.get("Content-Type", "text/csv; charset=utf-8"),
+        )
+        for header in ("Content-Disposition", "X-Export-Row-Count", "X-Export-Target-Date"):
+            if header in upstream.headers:
+                response[header] = upstream.headers[header]
+        return response
+
+    def _handle_http_error(self, e, project_uuid):
+        if e.response is None:
+            status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            body = {"error": "Internal server error"}
+        else:
+            status_code = e.response.status_code
+            content_type = e.response.headers.get("Content-Type", "")
+            if "application/json" in content_type:
+                try:
+                    body = e.response.json()
+                except ValueError:
+                    body = {"error": "Internal server error"}
+            else:
+                body = {"error": "Internal server error"}
+
+        logger.error(
+            "Conversations export failed for project %s: status_code=%s body=%s",
+            project_uuid,
+            status_code,
+            body,
+            exc_info=True,
+        )
+        return Response(body, status=status_code)
+
+    def _handle_generic_error(self, e, project_uuid):
+        logger.error(
+            "Error exporting conversations for project %s: %s",
+            project_uuid,
+            e,
+            exc_info=True,
+        )
         return Response({"error": "Internal server error"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -357,6 +357,10 @@ class ConversationsProxyView(APIView):
 class ConversationsExportProxyView(APIView):
     permission_classes = [IsAuthenticated, ProjectPermission | InternalCommunicationPermission]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.usecase = ConversationsUsecase()
+
     def post(self, request, *args, **kwargs):
         """
         Proxy endpoint to export conversations CSV from the Conversations service.
@@ -385,21 +389,16 @@ class ConversationsExportProxyView(APIView):
             return self._handle_generic_error(e, project_uuid)
 
     def _call_conversations_export(self, project_uuid, payload):
-        base_url = settings.CONVERSATIONS_REST_ENDPOINT.rstrip("/")
-        endpoint = f"/api/v1/projects/{project_uuid}/conversations/export/"
-        url = base_url + endpoint
-        headers = {
-            "Authorization": f"Bearer {settings.CONVERSATIONS_TOKEN}",
-            "Content-Type": "application/json",
-        }
-        response = requests.post(url, headers=headers, json=payload, timeout=120)
-        response.raise_for_status()
-        return response
+        return self.usecase.export_conversations_csv(
+            project_uuid,
+            target_date=payload.get("target_date"),
+        )
 
     def _build_csv_response(self, upstream):
         response = HttpResponse(
             upstream.content,
             content_type=upstream.headers.get("Content-Type", "text/csv; charset=utf-8"),
+            status=upstream.status_code,
         )
         for header in ("Content-Disposition", "X-Export-Row-Count", "X-Export-Target-Date"):
             if header in upstream.headers:

--- a/nexus/usecases/projects/conversations.py
+++ b/nexus/usecases/projects/conversations.py
@@ -83,6 +83,10 @@ class ConversationsUsecase:
             serializer.is_valid(raise_exception=True)
             return serializer.data
 
+    def export_conversations_csv(self, project_uuid: str, target_date: str | None = None):
+        """POST CSV export; returns raw requests.Response (body + headers)."""
+        return self.client.export_conversations_csv(project_uuid, target_date=target_date)
+
     def extract_error_message(self, response):
         """Extract error message from HTTP response."""
         error_message = str(response)


### PR DESCRIPTION
- Implemented a new ConversationsExportProxyView to handle CSV export requests for conversations.
- Added an export_conversations_csv method in ConversationsRESTClient to facilitate the export process.
- Updated routers to include the new export endpoint.
- Enhanced tests to verify permissions and functionality of the export feature.