### PR TITLE
feat: add Flows vs DB cohort reconcile endpoint

### DIFF
--- a/nexus/internals/conversations.py
+++ b/nexus/internals/conversations.py
@@ -87,7 +87,7 @@ class ConversationsRESTClient(RestClient):
             timeout=45,
         )
         response.raise_for_status()
-        return response
+        return response.json()
 
     def post_flows_db_cohort_reconcile(self, project_uuid: str, payload: dict):
         """
@@ -101,7 +101,8 @@ class ConversationsRESTClient(RestClient):
             json=payload,
             timeout=60,
         )
-        return response.json()
+        response.raise_for_status()
+        return response
 
     def get_topics(self, project_uuid: str):
         """Fetch all topics for a project, iterating through all pages."""

--- a/nexus/internals/conversations.py
+++ b/nexus/internals/conversations.py
@@ -87,6 +87,20 @@ class ConversationsRESTClient(RestClient):
             timeout=45,
         )
         response.raise_for_status()
+        return response
+
+    def post_flows_db_cohort_reconcile(self, project_uuid: str, payload: dict):
+        """
+        Queue async Flows vs DB cohort reconcile on the conversations service (202 + job_id).
+        ``payload`` must include recipient_email, flows_api_token, date_start, date_end, etc.
+        """
+        endpoint = f"/api/v1/projects/{project_uuid}/flows-db-cohort/"
+        response = requests.post(
+            self._get_url(endpoint),
+            headers={**self.headers, "Content-Type": "application/json"},
+            json=payload,
+            timeout=60,
+        )
         return response.json()
 
     def get_topics(self, project_uuid: str):

--- a/nexus/projects/api/routers.py
+++ b/nexus/projects/api/routers.py
@@ -6,6 +6,7 @@ from .views import (
     ConversationDetailProxyView,
     ConversationsProxyView,
     EnableHumanSupportView,
+    FlowsDbCohortReconcileProxyView,
     ProjectPromptCreationConfigurationsViewset,
     ProjectUpdateViewset,
 )
@@ -25,5 +26,10 @@ urlpatterns = [
         "v2/<project_uuid>/conversations/<conversation_uuid>",
         ConversationDetailProxyView.as_view(),
         name="conversation-detail-proxy-v2",
+    ),
+    path(
+        "v2/<project_uuid>/flows-db-cohort",
+        FlowsDbCohortReconcileProxyView.as_view(),
+        name="flows-db-cohort-reconcile-proxy-v2",
     ),
 ]

--- a/nexus/projects/api/tests/test_flows_db_cohort_reconcile_proxy.py
+++ b/nexus/projects/api/tests/test_flows_db_cohort_reconcile_proxy.py
@@ -1,15 +1,11 @@
 from unittest import mock
 from uuid import uuid4
 
-from django.test import TestCase
 from rest_framework import status
-from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.test import force_authenticate
 
+from nexus.projects.api.tests.test_conversations_proxy_permissions import _PermissionTestBase
 from nexus.projects.api.views import FlowsDbCohortReconcileProxyView
-from nexus.projects.models import Project
-from nexus.projects.permissions import has_project_permission
-from nexus.usecases.intelligences.tests.intelligence_factory import IntegratedIntelligenceFactory
-from nexus.usecases.users.tests.user_factory import UserFactory
 
 QUEUED_RESPONSE = {
     "status": "queued",
@@ -33,34 +29,14 @@ def _build_post_response(json_data, status_code=202):
     return resp
 
 
-class TestFlowsDbCohortReconcileProxyView(TestCase):
+@mock.patch("nexus.internals.conversations.ConversationsRESTClient.post_flows_db_cohort_reconcile")
+class TestFlowsDbCohortReconcileProxyView(_PermissionTestBase):
     def setUp(self):
-        integrated = IntegratedIntelligenceFactory()
-        self.project = integrated.project
-        self.project_uuid = str(self.project.uuid)
-        self.authorized_user = self.project.created_by
-        self.unauthorized_user = UserFactory()
-        self.factory = APIRequestFactory()
+        super().setUp()
         self.view = FlowsDbCohortReconcileProxyView.as_view()
         self.url = f"/api/v2/{self.project_uuid}/flows-db-cohort"
 
-        self._patcher = mock.patch("nexus.projects.api.permissions.has_external_general_project_permission")
-        self._mock_ext_perm = self._patcher.start()
-
-        def _local_permission(request, project_uuid, method):
-            try:
-                project = Project.objects.get(uuid=project_uuid)
-                return has_project_permission(request.user, project, method)
-            except Project.DoesNotExist:
-                return False
-
-        self._mock_ext_perm.side_effect = _local_permission
-
-    def tearDown(self):
-        self._patcher.stop()
-
-    @mock.patch("nexus.internals.conversations.ConversationsRESTClient.post_flows_db_cohort_reconcile")
-    def test_injects_recipient_email_from_user(self, mock_post):
+    def test_project_permission_grants_access(self, mock_post):
         mock_post.return_value = _build_post_response({**QUEUED_RESPONSE, "project_id": self.project_uuid})
 
         request = self.factory.post(
@@ -75,14 +51,33 @@ class TestFlowsDbCohortReconcileProxyView(TestCase):
         force_authenticate(request, user=self.authorized_user)
         response = self.view(request, project_uuid=self.project_uuid)
 
-        assert response.status_code == status.HTTP_202_ACCEPTED
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         mock_post.assert_called_once()
         _project_uuid, payload = mock_post.call_args[0]
-        assert payload["recipient_email"] == self.authorized_user.email
-        assert "flows_api_token" in payload
+        self.assertEqual(payload["recipient_email"], self.authorized_user.email)
+        self.assertIn("flows_api_token", payload)
 
-    @mock.patch("nexus.internals.conversations.ConversationsRESTClient.post_flows_db_cohort_reconcile")
-    def test_forbidden_without_project_permission(self, mock_post):
+    def test_internal_permission_grants_access_when_project_denied(self, mock_post):
+        mock_post.return_value = _build_post_response({**QUEUED_RESPONSE, "project_id": self.project_uuid})
+
+        request = self.factory.post(
+            self.url,
+            {
+                "flows_api_token": "secret",
+                "date_start": "2026-01-10T00:00:00Z",
+                "date_end": "2026-01-10T23:59:59Z",
+            },
+            format="json",
+        )
+        force_authenticate(request, user=self.internal_user)
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_post.assert_called_once()
+        _project_uuid, payload = mock_post.call_args[0]
+        self.assertEqual(payload["recipient_email"], self.internal_user.email)
+
+    def test_no_permission_returns_403(self, mock_post):
         request = self.factory.post(
             self.url,
             {
@@ -95,5 +90,20 @@ class TestFlowsDbCohortReconcileProxyView(TestCase):
         force_authenticate(request, user=self.unauthorized_user)
         response = self.view(request, project_uuid=self.project_uuid)
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_post.assert_not_called()
+
+    def test_unauthenticated_returns_401(self, mock_post):
+        request = self.factory.post(
+            self.url,
+            {
+                "flows_api_token": "secret",
+                "date_start": "2026-01-10T00:00:00Z",
+                "date_end": "2026-01-10T23:59:59Z",
+            },
+            format="json",
+        )
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         mock_post.assert_not_called()

--- a/nexus/projects/api/tests/test_flows_db_cohort_reconcile_proxy.py
+++ b/nexus/projects/api/tests/test_flows_db_cohort_reconcile_proxy.py
@@ -1,0 +1,99 @@
+from unittest import mock
+from uuid import uuid4
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from nexus.projects.api.views import FlowsDbCohortReconcileProxyView
+from nexus.projects.models import Project
+from nexus.projects.permissions import has_project_permission
+from nexus.usecases.intelligences.tests.intelligence_factory import IntegratedIntelligenceFactory
+from nexus.usecases.users.tests.user_factory import UserFactory
+
+QUEUED_RESPONSE = {
+    "status": "queued",
+    "job_id": "celery-job-abc",
+    "project_id": str(uuid4()),
+    "recipient_email": "owner@example.com",
+    "requested_range": {
+        "from_inclusive": "2026-01-10T00:00:00Z",
+        "to_inclusive": "2026-01-10T23:59:59Z",
+    },
+}
+
+
+def _build_post_response(json_data, status_code=202):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = ""
+    resp.reason = "Accepted"
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestFlowsDbCohortReconcileProxyView(TestCase):
+    def setUp(self):
+        integrated = IntegratedIntelligenceFactory()
+        self.project = integrated.project
+        self.project_uuid = str(self.project.uuid)
+        self.authorized_user = self.project.created_by
+        self.unauthorized_user = UserFactory()
+        self.factory = APIRequestFactory()
+        self.view = FlowsDbCohortReconcileProxyView.as_view()
+        self.url = f"/api/v2/{self.project_uuid}/flows-db-cohort"
+
+        self._patcher = mock.patch("nexus.projects.api.permissions.has_external_general_project_permission")
+        self._mock_ext_perm = self._patcher.start()
+
+        def _local_permission(request, project_uuid, method):
+            try:
+                project = Project.objects.get(uuid=project_uuid)
+                return has_project_permission(request.user, project, method)
+            except Project.DoesNotExist:
+                return False
+
+        self._mock_ext_perm.side_effect = _local_permission
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    @mock.patch("nexus.internals.conversations.ConversationsRESTClient.post_flows_db_cohort_reconcile")
+    def test_injects_recipient_email_from_user(self, mock_post):
+        mock_post.return_value = _build_post_response({**QUEUED_RESPONSE, "project_id": self.project_uuid})
+
+        request = self.factory.post(
+            self.url,
+            {
+                "flows_api_token": "secret",
+                "date_start": "2026-01-10T00:00:00Z",
+                "date_end": "2026-01-10T23:59:59Z",
+            },
+            format="json",
+        )
+        force_authenticate(request, user=self.authorized_user)
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_post.assert_called_once()
+        _project_uuid, payload = mock_post.call_args[0]
+        assert payload["recipient_email"] == self.authorized_user.email
+        assert "flows_api_token" in payload
+
+    @mock.patch("nexus.internals.conversations.ConversationsRESTClient.post_flows_db_cohort_reconcile")
+    def test_forbidden_without_project_permission(self, mock_post):
+        request = self.factory.post(
+            self.url,
+            {
+                "flows_api_token": "secret",
+                "date_start": "2026-01-10T00:00:00Z",
+                "date_end": "2026-01-10T23:59:59Z",
+            },
+            format="json",
+        )
+        force_authenticate(request, user=self.unauthorized_user)
+        response = self.view(request, project_uuid=self.project_uuid)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mock_post.assert_not_called()

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -529,3 +529,89 @@ class ConversationDetailProxyView(APIView):
         )
         self.usecase.send_to_sentry(project_uuid, None, error_message, None, exception=e)
         return Response({"error": "Internal server error"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class FlowsDbCohortReconcileProxyView(APIView):
+    """
+    Queue Flows vs DB cohort reconcile on the conversations service.
+    Injects ``recipient_email`` from the authenticated Nexus user.
+    """
+
+    permission_classes = [IsAuthenticated, ProjectPermission | InternalCommunicationPermission]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.usecase = ConversationsUsecase()
+
+    def post(self, request, *args, **kwargs):
+        project_uuid = kwargs.get("project_uuid")
+        if not project_uuid:
+            return Response({"error": "project_uuid is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        recipient_email = getattr(request.user, "email", None)
+        if not recipient_email:
+            return Response(
+                {"error": "Authenticated user has no email address"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        payload = dict(request.data)
+        payload.pop("recipient_email", None)
+        payload["recipient_email"] = recipient_email
+
+        try:
+            upstream = self.usecase.queue_flows_db_cohort_reconcile(project_uuid, payload)
+            try:
+                body = upstream.json()
+            except ValueError:
+                body = {"detail": upstream.text or upstream.reason}
+            return Response(body, status=upstream.status_code)
+        except requests.exceptions.HTTPError as e:
+            return self._handle_http_error(e, project_uuid)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RequestException,
+            Exception,
+        ) as e:
+            return self._handle_generic_error(e, project_uuid)
+
+    def _handle_http_error(self, e, project_uuid):
+        status_code = e.response.status_code if e.response else 500
+        try:
+            error_message, error_details = self.usecase.extract_error_message(e.response)
+        except Exception:
+            error_message = str(e)
+            error_details = None
+
+        if status_code != 404:
+            self.usecase.send_to_sentry(project_uuid, status_code, error_message, error_details, exception=e)
+
+        if status_code == 400:
+            return Response(error_details or {"error": error_message}, status=status.HTTP_400_BAD_REQUEST)
+        if status_code == 404:
+            return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+        if status_code == 502:
+            return Response(error_details or {"error": error_message}, status=status.HTTP_502_BAD_GATEWAY)
+        if status_code == 504:
+            return Response(error_details or {"error": error_message}, status=status.HTTP_504_GATEWAY_TIMEOUT)
+
+        logger.error(
+            "Flows DB cohort proxy error for project %s: status=%s message=%s",
+            project_uuid,
+            status_code,
+            error_message,
+            exc_info=True,
+        )
+        return Response({"error": "Internal server error"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def _handle_generic_error(self, e, project_uuid):
+        error_message = str(e)
+        logger.error(
+            "Flows DB cohort proxy error for project %s: %s",
+            project_uuid,
+            error_message,
+            exc_info=True,
+        )
+        self.usecase.send_to_sentry(project_uuid, None, error_message, None, exception=e)
+        return Response({"error": "Internal server error"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/nexus/usecases/projects/conversations.py
+++ b/nexus/usecases/projects/conversations.py
@@ -101,6 +101,12 @@ class ConversationsUsecase:
 
         return error_message, error_details
 
+    def queue_flows_db_cohort_reconcile(self, project_uuid: str, payload: dict):
+        """
+        Queue reconcile on conversations MS. Returns the raw ``requests.Response`` (expect 202).
+        """
+        return self.client.post_flows_db_cohort_reconcile(project_uuid, payload)
+
     def send_to_sentry(self, project_uuid, status_code, error_message, error_details, exception=None):
         """Centralized method to send error information to Sentry."""
         sentry_sdk.set_tag("project_uuid", project_uuid)


### PR DESCRIPTION
- Implemented a new API endpoint for queuing Flows vs DB cohort reconciliation, allowing users to submit a request with necessary parameters.
- Enhanced the ConversationsRESTClient to handle the new reconciliation request.
- Added a view to manage the reconciliation process, including error handling and recipient email injection.
- Created unit tests to validate the functionality and permission checks for the new endpoint.