### PR TITLE
fix(api): return catalog about shape on my-agents list

### DIFF
--- a/nexus/agents/api/test_agents_api.py
+++ b/nexus/agents/api/test_agents_api.py
@@ -122,6 +122,36 @@ class AgentViewsetSetTestCase(TestCase):
         row = next(c for c in content if c.get("uuid") == str(agent_grouped.uuid))
         self.assertEqual(row["name"], "Product Concierge")
 
+    def test_get_my_agents_returns_about_locale_map_from_modal(self):
+        group = AgentGroup.objects.create(name="About Group", slug="about-group-my-agents-unique")
+        AgentGroupModal.objects.create(
+            group=group,
+            agent_name="Catalog Agent",
+            about_en="About EN",
+            about_pt="About PT",
+            about_es="About ES",
+        )
+        agent_grouped = InlineAgent.objects.create(
+            name="Template",
+            slug="about-modal-my-agents",
+            instruction="x",
+            collaboration_instructions="fallback should not win",
+            foundation_model="model:version",
+            project=self.project,
+            group=group,
+        )
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("my-agents", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        response.render()
+        content = json.loads(response.content)
+        row = next(c for c in content if c.get("uuid") == str(agent_grouped.uuid))
+        self.assertEqual(row["about"]["en"], "About EN")
+        self.assertEqual(row["about"]["pt"], "About PT")
+        self.assertEqual(row["about"]["es"], "About ES")
+        self.assertNotIn("description", row)
+
     def test_get_my_agents_includes_mcp_definition(self):
         system = AgentSystem.objects.create(name="Test MCP System", slug="test-mcp-system-my-agents-xyz")
         mcp = MCP.objects.create(name="Test MCP", slug="test-mcp-my-agents-xyz", system=system)
@@ -159,13 +189,14 @@ class AgentViewsetSetTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         row = next(c for c in content if c.get("uuid") == str(agent_with_mcp.uuid))
-        self.assertIn("mcp_definitions", row)
-        self.assertEqual(len(row["mcp_definitions"]["config"]), 1)
-        self.assertEqual(row["mcp_definitions"]["config"][0]["name"], "REGION_TOGGLE")
-        self.assertEqual(len(row["mcp_definitions"]["credentials"]), 1)
-        self.assertEqual(row["mcp_definitions"]["credentials"][0]["name"], "SYNERISE_API_TOKEN")
-        cred_names = {c["name"] for c in row["credentials"]}
-        self.assertNotIn("SYNERISE_API_TOKEN", cred_names)
+        self.assertIn("about", row)
+        self.assertNotIn("description", row)
+        self.assertEqual(len(row["mcps"]), 1)
+        mcp_payload = row["mcps"][0]
+        self.assertEqual(len(mcp_payload["config"]), 1)
+        self.assertEqual(mcp_payload["config"][0]["name"], "REGION_TOGGLE")
+        self.assertEqual(len(mcp_payload["credentials"]), 1)
+        self.assertEqual(mcp_payload["credentials"][0]["name"], "SYNERISE_API_TOKEN")
 
 
 class TeamViewsetSetTestCase(TestCase):

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -693,13 +693,7 @@ class AgentsView(APIView):
             )
             agents = agents.filter(query_filter).distinct("uuid")
 
-        agents = agents.prefetch_related(
-            "systems",
-            "mcps",
-            "mcps__system",
-            "mcps__config_options",
-            "mcps__credential_templates",
-        )
+        agents = agents.prefetch_related("systems")
         assignment = (
             project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
         )

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -699,12 +699,12 @@ class AgentsView(APIView):
         )
         data = [
             build_row_from_project_agent(
-                a,
+                agent,
                 project_uuid,
                 include_inactive_integrated=False,
                 assignment_by_agent_id=assignment,
             )
-            for a in agents
+            for agent in agents
         ]
         return Response(data)
 

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -26,6 +26,10 @@ from nexus.inline_agents.api.serializers import (
     ProjectCredentialsListSerializer,
     TeamRosterAgentSerializer,
 )
+from nexus.inline_agents.api.serializers.catalog import (
+    build_row_from_project_agent,
+    project_agent_assignment_map,
+)
 from nexus.inline_agents.api.services.official_catalog import (
     bump_official_catalog_cache_generation,
     list_official_catalog_page,
@@ -679,9 +683,7 @@ class AgentsView(APIView):
         project_uuid = kwargs.get("project_uuid")
         search = self.request.query_params.get("search")
 
-        agents = _prefetch_inline_agent_mcp_credentials(
-            Agent.objects.filter(project__uuid=project_uuid).select_related("group", "group__modal")
-        )
+        agents = Agent.objects.filter(project__uuid=project_uuid).select_related("group", "group__modal")
 
         if search:
             query_filter = (
@@ -691,8 +693,26 @@ class AgentsView(APIView):
             )
             agents = agents.filter(query_filter).distinct("uuid")
 
-        serializer = AgentSerializer(agents, many=True, context={"project_uuid": project_uuid})
-        return Response(serializer.data)
+        agents = agents.prefetch_related(
+            "systems",
+            "mcps",
+            "mcps__system",
+            "mcps__config_options",
+            "mcps__credential_templates",
+        )
+        assignment = (
+            project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
+        )
+        data = [
+            build_row_from_project_agent(
+                a,
+                project_uuid,
+                include_inactive_integrated=False,
+                assignment_by_agent_id=assignment,
+            )
+            for a in agents
+        ]
+        return Response(data)
 
 
 class AgentProjectsView(APIView):


### PR DESCRIPTION
Restore build_row_from_project_agent for GET /api/agents/my-agents so responses expose localized about (not legacy description). Regression came from merge conflict resolution that switched back to AgentSerializer.