### PR TITLE
feat: add projects resolution rate endpoint

### DIFF
--- a/nexus/internals/conversations.py
+++ b/nexus/internals/conversations.py
@@ -89,6 +89,36 @@ class ConversationsRESTClient(RestClient):
         response.raise_for_status()
         return response.json()
 
+    def get_projects_resolution_summary(
+        self,
+        *,
+        project_uuids: list[str] | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        timeout: int = 60,
+    ) -> dict:
+        """
+        Aggregated resolution, CSAT and NPS metrics for multiple projects (internal endpoint).
+        """
+        endpoint = "/api/v1/projects/resolution-summary/"
+        params: list[tuple[str, str]] = []
+        if start_date is not None:
+            params.append(("start_date", start_date))
+        if end_date is not None:
+            params.append(("end_date", end_date))
+        if project_uuids:
+            for project_uuid in project_uuids:
+                params.append(("project_uuids", project_uuid))
+
+        response = requests.get(
+            self._get_url(endpoint),
+            headers=self.headers,
+            params=params or None,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
     def get_reconcile_cohort(
         self,
         project_uuid: str,

--- a/nexus/projects/api/resolution_rate_serializers.py
+++ b/nexus/projects/api/resolution_rate_serializers.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+
+
+class ProjectsResolutionRateItemSerializer(serializers.Serializer):
+    project_uuid = serializers.UUIDField()
+    project_name = serializers.CharField()
+    resolution_rate = serializers.FloatField()
+    conversation_count = serializers.IntegerField(required=False)
+    resolved_count = serializers.IntegerField(required=False)
+    unresolved_count = serializers.IntegerField(required=False)
+    human_support_count = serializers.IntegerField(required=False)
+    csat = serializers.FloatField(allow_null=True, required=False)
+    csat_responses_count = serializers.IntegerField(required=False)
+    nps = serializers.FloatField(allow_null=True, required=False)
+    nps_responses_count = serializers.IntegerField(required=False)
+    manager = serializers.CharField(required=False)
+    uses_components = serializers.BooleanField(required=False)
+    agents_count = serializers.IntegerField(required=False)
+    official_agents_count = serializers.IntegerField(required=False)
+
+
+class ProjectsResolutionRateResponseSerializer(serializers.Serializer):
+    count = serializers.IntegerField()
+    page = serializers.IntegerField()
+    page_size = serializers.IntegerField()
+    start_date = serializers.CharField(allow_null=True, required=False)
+    end_date = serializers.CharField(allow_null=True, required=False)
+    average_resolution_rate = serializers.FloatField()
+    average_csat = serializers.FloatField(allow_null=True)
+    average_nps = serializers.FloatField(allow_null=True)
+    results = ProjectsResolutionRateItemSerializer(many=True)

--- a/nexus/projects/api/resolution_rate_views.py
+++ b/nexus/projects/api/resolution_rate_views.py
@@ -10,7 +10,9 @@ from nexus.internals.conversations import ConversationsRESTClient
 from nexus.projects.services.projects_resolution_rate import (
     ResolutionRateQuery,
     build_response,
+    conversations_fetch_project_uuids,
     eligible_projects_queryset,
+    empty_summary_averages,
     log_conversations_failure,
     parse_calendar_date,
     parse_include_blocks,
@@ -18,6 +20,7 @@ from nexus.projects.services.projects_resolution_rate import (
     parse_page_size,
     parse_project_uuids,
     resolve_calendar_range,
+    resolve_projects_for_response,
 )
 from nexus.users.api.authentication import UserGlobalTokenAuthentication
 
@@ -43,26 +46,33 @@ class ProjectsResolutionRateView(APIView):
         except ValueError as exc:
             return self._validation_error_response(str(exc))
 
-        projects = list(eligible_projects_queryset(query.project_uuids))
-        if not projects:
-            payload = build_response(query=query, summary_payload={}, projects=[])
+        eligible_projects = list(eligible_projects_queryset(query.project_uuids))
+        if not eligible_projects:
+            payload = build_response(
+                query=query,
+                summary_payload={},
+                projects=[],
+                period_averages=empty_summary_averages(),
+            )
             serializer = ProjectsResolutionRateResponseSerializer(data=payload)
             serializer.is_valid(raise_exception=True)
             return Response(payload, status=status.HTTP_200_OK)
 
-        project_uuid_strings = [str(project.uuid) for project in projects]
+        fetch_uuids = conversations_fetch_project_uuids(query, eligible_projects)
         start_param = query.start_date.isoformat() if query.start_date else None
         end_param = query.end_date.isoformat() if query.end_date else None
+        log_uuids = fetch_uuids or []
 
         try:
             summary_payload = ConversationsRESTClient().get_projects_resolution_summary(
-                project_uuids=project_uuid_strings,
+                project_uuids=fetch_uuids,
                 start_date=start_param,
                 end_date=end_param,
+                timeout=120 if fetch_uuids is None else 60,
             )
         except requests.HTTPError as exc:
             log_conversations_failure(
-                project_uuids=project_uuid_strings,
+                project_uuids=log_uuids,
                 start_date=start_param,
                 end_date=end_param,
                 exc=exc,
@@ -70,7 +80,7 @@ class ProjectsResolutionRateView(APIView):
             return self._downstream_error_response(exc)
         except requests.RequestException as exc:
             log_conversations_failure(
-                project_uuids=project_uuid_strings,
+                project_uuids=log_uuids,
                 start_date=start_param,
                 end_date=end_param,
                 exc=exc,
@@ -80,7 +90,17 @@ class ProjectsResolutionRateView(APIView):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
-        payload = build_response(query=query, summary_payload=summary_payload, projects=projects)
+        projects, period_averages = resolve_projects_for_response(
+            query=query,
+            summary_payload=summary_payload,
+            eligible_projects=eligible_projects,
+        )
+        payload = build_response(
+            query=query,
+            summary_payload=summary_payload,
+            projects=projects,
+            period_averages=period_averages,
+        )
         serializer = ProjectsResolutionRateResponseSerializer(data=payload)
         serializer.is_valid(raise_exception=True)
         return Response(payload, status=status.HTTP_200_OK)

--- a/nexus/projects/api/resolution_rate_views.py
+++ b/nexus/projects/api/resolution_rate_views.py
@@ -1,0 +1,141 @@
+import requests
+from mozilla_django_oidc.contrib.drf import OIDCAuthentication
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from nexus.analytics.api.views import InternalCommunicationPermission
+from nexus.authentication.authentication import ExternalTokenAuthentication
+from nexus.internals.conversations import ConversationsRESTClient
+from nexus.projects.services.projects_resolution_rate import (
+    ResolutionRateQuery,
+    build_response,
+    eligible_projects_queryset,
+    log_conversations_failure,
+    parse_calendar_date,
+    parse_include_blocks,
+    parse_page,
+    parse_page_size,
+    parse_project_uuids,
+    resolve_calendar_range,
+)
+from nexus.users.api.authentication import UserGlobalTokenAuthentication
+
+from .resolution_rate_serializers import ProjectsResolutionRateResponseSerializer
+
+
+class ProjectsResolutionRateView(APIView):
+    """
+    GET /api/v2/projects/resolution-rate
+
+    Internal endpoint: conversation metrics from nexus-conversations plus project metadata from nexus-ai.
+    """
+
+    authentication_classes = [UserGlobalTokenAuthentication, ExternalTokenAuthentication, OIDCAuthentication]
+    permission_classes = [InternalCommunicationPermission]
+
+    def get(self, request):
+        if getattr(self, "swagger_fake_view", False):
+            return Response({})
+
+        try:
+            query = self._parse_query(request)
+        except ValueError as exc:
+            return self._validation_error_response(str(exc))
+
+        projects = list(eligible_projects_queryset(query.project_uuids))
+        if not projects:
+            payload = build_response(query=query, summary_payload={}, projects=[])
+            serializer = ProjectsResolutionRateResponseSerializer(data=payload)
+            serializer.is_valid(raise_exception=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        project_uuid_strings = [str(project.uuid) for project in projects]
+        start_param = query.start_date.isoformat() if query.start_date else None
+        end_param = query.end_date.isoformat() if query.end_date else None
+
+        try:
+            summary_payload = ConversationsRESTClient().get_projects_resolution_summary(
+                project_uuids=project_uuid_strings,
+                start_date=start_param,
+                end_date=end_param,
+            )
+        except requests.HTTPError as exc:
+            log_conversations_failure(
+                project_uuids=project_uuid_strings,
+                start_date=start_param,
+                end_date=end_param,
+                exc=exc,
+            )
+            return self._downstream_error_response(exc)
+        except requests.RequestException as exc:
+            log_conversations_failure(
+                project_uuids=project_uuid_strings,
+                start_date=start_param,
+                end_date=end_param,
+                exc=exc,
+            )
+            return Response(
+                {"error": "Conversations service unavailable"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        payload = build_response(query=query, summary_payload=summary_payload, projects=projects)
+        serializer = ProjectsResolutionRateResponseSerializer(data=payload)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def _parse_query(self, request) -> ResolutionRateQuery:
+        raw_uuids = request.query_params.getlist("project_uuids")
+        project_uuids = parse_project_uuids(raw_uuids) or None
+
+        start_raw = request.query_params.get("start_date")
+        end_raw = request.query_params.get("end_date")
+        start_date = parse_calendar_date(start_raw, "start_date") if start_raw else None
+        end_date = parse_calendar_date(end_raw, "end_date") if end_raw else None
+        start_date, end_date = resolve_calendar_range(start_date, end_date)
+
+        page = parse_page(request.query_params.get("page"))
+        page_size = parse_page_size(request.query_params.get("page_size"))
+        include_blocks = parse_include_blocks(request.query_params.get("include"))
+
+        return ResolutionRateQuery(
+            project_uuids=project_uuids,
+            start_date=start_date,
+            end_date=end_date,
+            page=page,
+            page_size=page_size,
+            include_blocks=include_blocks,
+        )
+
+    @staticmethod
+    def _validation_error_response(message: str) -> Response:
+        lowered = message.lower()
+        if "project uuid" in lowered:
+            field = "project_uuids"
+        elif "start_date" in lowered and "end_date" in lowered and "both" in lowered:
+            return Response({"start_date": [message], "end_date": [message]}, status=status.HTTP_400_BAD_REQUEST)
+        elif "start_date" in lowered:
+            field = "start_date"
+        elif "end_date" in lowered:
+            field = "end_date"
+        elif "include" in lowered:
+            field = "include"
+        elif "page_size" in lowered:
+            field = "page_size"
+        elif "page" in lowered:
+            field = "page"
+        else:
+            field = "detail"
+        return Response({field: [message]}, status=status.HTTP_400_BAD_REQUEST)
+
+    @staticmethod
+    def _downstream_error_response(exc: requests.HTTPError) -> Response:
+        status_code = exc.response.status_code if exc.response is not None else status.HTTP_503_SERVICE_UNAVAILABLE
+        if status_code == status.HTTP_502_BAD_GATEWAY:
+            http_status = status.HTTP_502_BAD_GATEWAY
+        elif status_code >= 500:
+            http_status = status.HTTP_503_SERVICE_UNAVAILABLE
+        else:
+            http_status = status.HTTP_503_SERVICE_UNAVAILABLE
+        return Response({"error": "Conversations service unavailable"}, status=http_status)

--- a/nexus/projects/api/resolution_rate_views.py
+++ b/nexus/projects/api/resolution_rate_views.py
@@ -48,7 +48,7 @@ class ProjectsResolutionRateView(APIView):
             payload = build_response(query=query, summary_payload={}, projects=[])
             serializer = ProjectsResolutionRateResponseSerializer(data=payload)
             serializer.is_valid(raise_exception=True)
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response(payload, status=status.HTTP_200_OK)
 
         project_uuid_strings = [str(project.uuid) for project in projects]
         start_param = query.start_date.isoformat() if query.start_date else None
@@ -83,7 +83,7 @@ class ProjectsResolutionRateView(APIView):
         payload = build_response(query=query, summary_payload=summary_payload, projects=projects)
         serializer = ProjectsResolutionRateResponseSerializer(data=payload)
         serializer.is_valid(raise_exception=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(payload, status=status.HTTP_200_OK)
 
     def _parse_query(self, request) -> ResolutionRateQuery:
         raw_uuids = request.query_params.getlist("project_uuids")

--- a/nexus/projects/api/routers.py
+++ b/nexus/projects/api/routers.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from .resolution_rate_views import ProjectsResolutionRateView
 from .views import (
     AgentBuilderProjectDetailsView,
     AgentsBackendView,
@@ -22,6 +23,7 @@ urlpatterns = [
     path("<project_uuid>/agents-backend", AgentsBackendView.as_view(), name="agents-backend"),
     path("<project_uuid>/human-support", EnableHumanSupportView.as_view(), name="enable-human-support"),
     path("<project_uuid>/ab-project-details", AgentBuilderProjectDetailsView.as_view(), name="ab-project-details"),
+    path("v2/projects/resolution-rate", ProjectsResolutionRateView.as_view(), name="projects-resolution-rate-v2"),
     path("v2/<project_uuid>/conversations", ConversationsProxyView.as_view(), name="conversations-proxy-v2"),
     path(
         "v2/<project_uuid>/conversations/export",

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -1,0 +1,325 @@
+from unittest import mock
+from uuid import uuid4
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from nexus.inline_agents.backends.openai.models import ManagerAgent
+from nexus.inline_agents.models import Agent
+from nexus.projects.api.resolution_rate_views import ProjectsResolutionRateView
+from nexus.projects.models import Project
+from nexus.projects.services.projects_resolution_rate import (
+    apply_include_blocks,
+    parse_page_size,
+    sort_result_rows,
+)
+from nexus.usecases.intelligences.tests.intelligence_factory import IntegratedIntelligenceFactory
+from nexus.usecases.users.tests.user_factory import UserFactory
+
+SUMMARY_PAYLOAD = {
+    "start_date": "2026-05-19",
+    "end_date": "2026-05-25",
+    "average_resolution_rate": 0.5,
+    "average_csat": 4.0,
+    "average_nps": 8.0,
+    "projects": [],
+}
+
+
+def _summary_for_projects(projects_metrics):
+    return {
+        **SUMMARY_PAYLOAD,
+        "projects": projects_metrics,
+    }
+
+
+@mock.patch("nexus.projects.api.resolution_rate_views.ConversationsRESTClient.get_projects_resolution_summary")
+class TestProjectsResolutionRateView(TestCase):
+    def setUp(self):
+        integrated = IntegratedIntelligenceFactory()
+        self.ab2_project = integrated.project
+        self.ab2_project.agents_backend = "BedrockBackend"
+        self.ab2_project.save(update_fields=["agents_backend"])
+
+        self.ab25_project = Project.objects.create(
+            name="AB 2.5 Project",
+            org=self.ab2_project.org,
+            created_by=self.ab2_project.created_by,
+            agents_backend="OpenAIBackend",
+        )
+
+        self.manager = ManagerAgent.objects.create(
+            name="Manager X",
+            base_prompt="Manager prompt",
+            release_date=timezone.now(),
+            foundation_model="gpt-4",
+            model_vendor="openai",
+            collaborators_foundation_model="gpt-4o-mini",
+            formatter_agent_foundation_model="gpt-4o-mini",
+        )
+        self.ab2_project.manager_agent = self.manager
+        self.ab2_project.use_components = True
+        self.ab2_project.save(update_fields=["manager_agent", "use_components"])
+
+        Agent.objects.create(
+            name="Official",
+            slug="official-agent",
+            project=self.ab2_project,
+            instruction="i",
+            collaboration_instructions="c",
+            is_official=True,
+        )
+        Agent.objects.create(
+            name="Custom",
+            slug="custom-agent",
+            project=self.ab2_project,
+            instruction="i",
+            collaboration_instructions="c",
+            is_official=False,
+        )
+
+        self.internal_user = UserFactory()
+        ct = ContentType.objects.get_for_model(self.internal_user)
+        perm, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=ct,
+        )
+        self.internal_user.user_permissions.add(perm)
+        self.internal_user = type(self.internal_user).objects.get(pk=self.internal_user.pk)
+
+        self.factory = APIRequestFactory()
+        self.view = ProjectsResolutionRateView.as_view()
+        self.url = reverse("projects-resolution-rate-v2")
+
+    def _get(self, params=None, user=None):
+        request = self.factory.get(self.url, data=params or {})
+        force_authenticate(request, user=user or self.internal_user)
+        return self.view(request)
+
+    def test_requires_internal_permission(self, mock_summary):
+        response = self._get(user=UserFactory())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_summary.assert_not_called()
+
+    def test_invalid_project_uuid_returns_400(self, mock_summary):
+        response = self._get({"project_uuids": "not-a-uuid"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_summary.assert_not_called()
+
+    def test_invalid_date_returns_400(self, mock_summary):
+        response = self._get({"start_date": "bad-date"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_summary.assert_not_called()
+
+    def test_partial_date_range_returns_400(self, mock_summary):
+        response = self._get({"start_date": "2026-05-01"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_summary.assert_not_called()
+
+    def test_success_merges_conversations_and_local_metadata(self, mock_summary):
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 10,
+                    "resolved_count": 8,
+                    "unresolved_count": 1,
+                    "human_support_count": 1,
+                    "resolution_rate": 0.8,
+                    "csat": 4.5,
+                    "csat_responses_count": 2,
+                    "nps": 9.0,
+                    "nps_responses_count": 1,
+                }
+            ]
+        )
+        response = self._get(
+            {
+                "project_uuids": str(self.ab2_project.uuid),
+                "start_date": "2026-05-19",
+                "end_date": "2026-05-25",
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        row = response.data["results"][0]
+        self.assertEqual(row["project_name"], self.ab2_project.name)
+        self.assertEqual(row["manager"], "Manager X")
+        self.assertTrue(row["uses_components"])
+        self.assertEqual(row["agents_count"], 2)
+        self.assertEqual(row["official_agents_count"], 1)
+        self.assertEqual(row["conversation_count"], 10)
+        self.assertEqual(response.data["average_resolution_rate"], 0.5)
+        mock_summary.assert_called_once()
+
+    def test_filters_only_ab2_projects(self, mock_summary):
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 1,
+                    "resolved_count": 1,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 1.0,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                }
+            ]
+        )
+        response = self._get(
+            {
+                "project_uuids": f"{self.ab2_project.uuid},{self.ab25_project.uuid}",
+                "start_date": "2026-05-19",
+                "end_date": "2026-05-25",
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        called_uuids = mock_summary.call_args.kwargs["project_uuids"]
+        self.assertEqual(called_uuids, [str(self.ab2_project.uuid)])
+
+    def test_manager_fallback_when_missing(self, mock_summary):
+        self.ab2_project.manager_agent = None
+        self.ab2_project.save(update_fields=["manager_agent"])
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 0,
+                    "resolved_count": 0,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 0.0,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                }
+            ]
+        )
+        response = self._get({"project_uuids": str(self.ab2_project.uuid)})
+        self.assertEqual(response.data["results"][0]["manager"], "2.5")
+
+    def test_include_limits_optional_blocks(self, mock_summary):
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 1,
+                    "resolved_count": 1,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 1.0,
+                    "csat": 5.0,
+                    "csat_responses_count": 1,
+                    "nps": 10.0,
+                    "nps_responses_count": 1,
+                }
+            ]
+        )
+        response = self._get(
+            {
+                "project_uuids": str(self.ab2_project.uuid),
+                "include": "manager,agents",
+            }
+        )
+        row = response.data["results"][0]
+        self.assertIn("resolution_rate", row)
+        self.assertIn("manager", row)
+        self.assertIn("agents_count", row)
+        self.assertNotIn("conversation_count", row)
+        self.assertNotIn("csat", row)
+
+    def test_pagination_and_sorting(self, mock_summary):
+        other = Project.objects.create(
+            name="AAA Other",
+            org=self.ab2_project.org,
+            created_by=self.ab2_project.created_by,
+            agents_backend="BedrockBackend",
+        )
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 5,
+                    "resolved_count": 2,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 0.4,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                },
+                {
+                    "project_uuid": str(other.uuid),
+                    "conversation_count": 10,
+                    "resolved_count": 9,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 0.9,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                },
+            ]
+        )
+        response = self._get({"page": 1, "page_size": 1})
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["project_uuid"], str(other.uuid))
+        self.assertEqual(response.data["average_resolution_rate"], 0.5)
+
+    def test_conversations_failure_returns_503(self, mock_summary):
+        import requests
+
+        mock_summary.side_effect = requests.ConnectionError("down")
+        response = self._get({"project_uuids": str(self.ab2_project.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    def test_no_visible_projects_returns_empty_payload(self, mock_summary):
+        response = self._get({"project_uuids": str(uuid4())})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])
+        self.assertEqual(response.data["average_resolution_rate"], 0.0)
+        self.assertIsNone(response.data["average_csat"])
+        mock_summary.assert_not_called()
+
+
+class TestProjectsResolutionRateServiceHelpers(TestCase):
+    def test_parse_page_size_truncates_above_100(self):
+        self.assertEqual(parse_page_size("500"), 100)
+
+    def test_sort_result_rows_orders_by_resolution_rate(self):
+        rows = sort_result_rows(
+            [
+                {"project_name": "B", "resolution_rate": 0.2, "conversation_count": 10},
+                {"project_name": "A", "resolution_rate": 0.8, "conversation_count": 1},
+                {"project_name": "C", "resolution_rate": 0.8, "conversation_count": 5},
+            ]
+        )
+        self.assertEqual([row["project_name"] for row in rows], ["C", "A", "B"])
+
+    def test_apply_include_blocks_keeps_resolution_rate(self):
+        row = apply_include_blocks(
+            {
+                "project_uuid": "x",
+                "project_name": "n",
+                "resolution_rate": 0.5,
+                "conversation_count": 1,
+                "manager": "m",
+            },
+            {"manager"},
+        )
+        self.assertEqual(row["resolution_rate"], 0.5)
+        self.assertNotIn("conversation_count", row)

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -130,6 +130,28 @@ class TestProjectsResolutionRateView(TestCase):
         assert "page_size" in response.data
         mock_summary.assert_not_called()
 
+    def test_client_called_with_single_batch_not_per_project(self, mock_summary):
+        other = Project.objects.create(
+            name="Batch Other",
+            org=self.ab2_project.org,
+            created_by=self.ab2_project.created_by,
+            agents_backend="BedrockBackend",
+        )
+        mock_summary.return_value = _summary_for_projects([])
+        self._get(
+            {
+                "project_uuids": f"{self.ab2_project.uuid},{other.uuid}",
+                "start_date": "2026-05-19",
+                "end_date": "2026-05-25",
+            }
+        )
+        mock_summary.assert_called_once()
+        called_uuids = set(mock_summary.call_args.kwargs["project_uuids"])
+        self.assertEqual(
+            called_uuids,
+            {str(self.ab2_project.uuid), str(other.uuid)},
+        )
+
     def test_success_merges_conversations_and_local_metadata(self, mock_summary):
         mock_summary.return_value = _summary_for_projects(
             [
@@ -293,6 +315,91 @@ class TestProjectsResolutionRateView(TestCase):
         mock_summary.side_effect = requests.ConnectionError("down")
         response = self._get({"project_uuids": str(self.ab2_project.uuid)})
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    def test_conversations_http_502_returns_502(self, mock_summary):
+        import requests
+
+        exc = requests.HTTPError("bad gateway")
+        exc.response = mock.Mock(status_code=status.HTTP_502_BAD_GATEWAY)
+        mock_summary.side_effect = exc
+        response = self._get({"project_uuids": str(self.ab2_project.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    def test_page_size_over_100_is_truncated_in_response(self, mock_summary):
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 1,
+                    "resolved_count": 1,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 1.0,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                }
+            ]
+        )
+        response = self._get(
+            {
+                "project_uuids": str(self.ab2_project.uuid),
+                "page_size": "150",
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["page_size"], 100)
+
+    def test_period_averages_stable_across_pages(self, mock_summary):
+        other = Project.objects.create(
+            name="ZZZ Other",
+            org=self.ab2_project.org,
+            created_by=self.ab2_project.created_by,
+            agents_backend="BedrockBackend",
+        )
+        summary = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.ab2_project.uuid),
+                    "conversation_count": 1,
+                    "resolved_count": 0,
+                    "unresolved_count": 1,
+                    "human_support_count": 0,
+                    "resolution_rate": 0.0,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                },
+                {
+                    "project_uuid": str(other.uuid),
+                    "conversation_count": 1,
+                    "resolved_count": 1,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 1.0,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                },
+            ]
+        )
+        summary["average_resolution_rate"] = 0.5
+        summary["average_csat"] = 4.0
+        summary["average_nps"] = 8.0
+        mock_summary.return_value = summary
+
+        page_one = self._get({"page": 1, "page_size": 1})
+        page_two = self._get({"page": 2, "page_size": 1})
+        self.assertEqual(page_one.status_code, status.HTTP_200_OK)
+        self.assertEqual(page_two.status_code, status.HTTP_200_OK)
+        self.assertEqual(page_one.data["count"], 2)
+        self.assertEqual(page_one.data["average_resolution_rate"], 0.5)
+        self.assertEqual(page_two.data["average_resolution_rate"], 0.5)
+        self.assertEqual(page_one.data["average_csat"], 4.0)
+        self.assertEqual(page_two.data["average_csat"], 4.0)
 
     def test_no_visible_projects_returns_empty_payload(self, mock_summary):
         response = self._get({"project_uuids": str(uuid4())})

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -330,11 +330,19 @@ class TestProjectsResolutionRateView(TestCase):
                 },
             ]
         )
-        response = self._get({"page": 1, "page_size": 1})
+        response = self._get(
+            {
+                "start_date": "2026-05-19",
+                "end_date": "2026-05-25",
+                "page": 1,
+                "page_size": 1,
+            }
+        )
         self.assertEqual(response.data["count"], 2)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["project_uuid"], str(other.uuid))
-        self.assertEqual(response.data["average_resolution_rate"], 0.5)
+        # Period average is recomputed from eligible AB2 rows with activity (not mock envelope).
+        self.assertEqual(response.data["average_resolution_rate"], 0.65)
 
     def test_without_project_uuids_does_not_send_all_uuids_to_conversations(self, mock_summary):
         inactive = Project.objects.create(
@@ -463,20 +471,23 @@ class TestProjectsResolutionRateView(TestCase):
                 },
             ]
         )
-        summary["average_resolution_rate"] = 0.5
-        summary["average_csat"] = 4.0
-        summary["average_nps"] = 8.0
         mock_summary.return_value = summary
 
-        page_one = self._get({"page": 1, "page_size": 1})
-        page_two = self._get({"page": 2, "page_size": 1})
+        query = {
+            "start_date": "2026-05-19",
+            "end_date": "2026-05-25",
+            "page": 1,
+            "page_size": 1,
+        }
+        page_one = self._get(query)
+        page_two = self._get({**query, "page": 2})
         self.assertEqual(page_one.status_code, status.HTTP_200_OK)
         self.assertEqual(page_two.status_code, status.HTTP_200_OK)
         self.assertEqual(page_one.data["count"], 2)
         self.assertEqual(page_one.data["average_resolution_rate"], 0.5)
         self.assertEqual(page_two.data["average_resolution_rate"], 0.5)
-        self.assertEqual(page_one.data["average_csat"], 4.0)
-        self.assertEqual(page_two.data["average_csat"], 4.0)
+        self.assertIsNone(page_one.data["average_csat"])
+        self.assertIsNone(page_two.data["average_csat"])
 
     def test_no_visible_projects_returns_empty_payload(self, mock_summary):
         response = self._get({"project_uuids": str(uuid4())})

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -14,10 +14,12 @@ from nexus.inline_agents.models import Agent
 from nexus.projects.api.resolution_rate_views import ProjectsResolutionRateView
 from nexus.projects.models import Project
 from nexus.projects.services.projects_resolution_rate import (
+    CONVERSATIONS_METRICS_EARLIEST_DATE,
     apply_include_blocks,
     build_result_rows,
     parse_calendar_date,
     parse_page_size,
+    resolve_calendar_range,
     sort_result_rows,
 )
 from nexus.usecases.intelligences.tests.intelligence_factory import IntegratedIntelligenceFactory
@@ -45,15 +47,15 @@ def _summary_for_projects(projects_metrics):
 class TestProjectsResolutionRateView(TestCase):
     def setUp(self):
         integrated = IntegratedIntelligenceFactory()
-        self.ab2_project = integrated.project
-        self.ab2_project.agents_backend = "BedrockBackend"
-        self.ab2_project.save(update_fields=["agents_backend"])
+        self.eligible_project = integrated.project
+        self.eligible_project.inline_agent_switch = True
+        self.eligible_project.save(update_fields=["inline_agent_switch"])
 
-        self.ab25_project = Project.objects.create(
-            name="AB 2.5 Project",
-            org=self.ab2_project.org,
-            created_by=self.ab2_project.created_by,
-            agents_backend="OpenAIBackend",
+        self.ab1_project = Project.objects.create(
+            name="AB 1 Project",
+            org=self.eligible_project.org,
+            created_by=self.eligible_project.created_by,
+            inline_agent_switch=False,
         )
 
         self.manager = ManagerAgent.objects.create(
@@ -65,14 +67,14 @@ class TestProjectsResolutionRateView(TestCase):
             collaborators_foundation_model="gpt-4o-mini",
             formatter_agent_foundation_model="gpt-4o-mini",
         )
-        self.ab2_project.manager_agent = self.manager
-        self.ab2_project.use_components = True
-        self.ab2_project.save(update_fields=["manager_agent", "use_components"])
+        self.eligible_project.manager_agent = self.manager
+        self.eligible_project.use_components = True
+        self.eligible_project.save(update_fields=["manager_agent", "use_components"])
 
         Agent.objects.create(
             name="Official",
             slug="official-agent",
-            project=self.ab2_project,
+            project=self.eligible_project,
             instruction="i",
             collaboration_instructions="c",
             is_official=True,
@@ -80,7 +82,7 @@ class TestProjectsResolutionRateView(TestCase):
         Agent.objects.create(
             name="Custom",
             slug="custom-agent",
-            project=self.ab2_project,
+            project=self.eligible_project,
             instruction="i",
             collaboration_instructions="c",
             is_official=False,
@@ -125,8 +127,32 @@ class TestProjectsResolutionRateView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         mock_summary.assert_not_called()
 
+    def test_start_date_before_go_live_returns_400(self, mock_summary):
+        response = self._get(
+            {
+                "project_uuids": str(self.eligible_project.uuid),
+                "start_date": "2026-03-27",
+                "end_date": "2026-05-25",
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "start_date" in response.data
+        mock_summary.assert_not_called()
+
+    def test_end_date_before_go_live_returns_400(self, mock_summary):
+        response = self._get(
+            {
+                "project_uuids": str(self.eligible_project.uuid),
+                "start_date": "2026-04-01",
+                "end_date": "2026-03-27",
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "end_date" in response.data
+        mock_summary.assert_not_called()
+
     def test_invalid_page_size_returns_400(self, mock_summary):
-        response = self._get({"project_uuids": str(self.ab2_project.uuid), "page_size": "0"})
+        response = self._get({"project_uuids": str(self.eligible_project.uuid), "page_size": "0"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert "page_size" in response.data
         mock_summary.assert_not_called()
@@ -134,14 +160,14 @@ class TestProjectsResolutionRateView(TestCase):
     def test_client_called_with_single_batch_not_per_project(self, mock_summary):
         other = Project.objects.create(
             name="Batch Other",
-            org=self.ab2_project.org,
-            created_by=self.ab2_project.created_by,
-            agents_backend="BedrockBackend",
+            org=self.eligible_project.org,
+            created_by=self.eligible_project.created_by,
+            inline_agent_switch=True,
         )
         mock_summary.return_value = _summary_for_projects([])
         self._get(
             {
-                "project_uuids": f"{self.ab2_project.uuid},{other.uuid}",
+                "project_uuids": f"{self.eligible_project.uuid},{other.uuid}",
                 "start_date": "2026-05-19",
                 "end_date": "2026-05-25",
             }
@@ -150,14 +176,14 @@ class TestProjectsResolutionRateView(TestCase):
         called_uuids = set(mock_summary.call_args.kwargs["project_uuids"])
         self.assertEqual(
             called_uuids,
-            {str(self.ab2_project.uuid), str(other.uuid)},
+            {str(self.eligible_project.uuid), str(other.uuid)},
         )
 
     def test_success_merges_conversations_and_local_metadata(self, mock_summary):
         mock_summary.return_value = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 10,
                     "resolved_count": 8,
                     "unresolved_count": 1,
@@ -172,14 +198,14 @@ class TestProjectsResolutionRateView(TestCase):
         )
         response = self._get(
             {
-                "project_uuids": str(self.ab2_project.uuid),
+                "project_uuids": str(self.eligible_project.uuid),
                 "start_date": "2026-05-19",
                 "end_date": "2026-05-25",
             }
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         row = response.data["results"][0]
-        self.assertEqual(row["project_name"], self.ab2_project.name)
+        self.assertEqual(row["project_name"], self.eligible_project.name)
         self.assertEqual(row["manager"], "Manager X")
         self.assertTrue(row["uses_components"])
         self.assertEqual(row["agents_count"], 2)
@@ -188,11 +214,11 @@ class TestProjectsResolutionRateView(TestCase):
         self.assertEqual(response.data["average_resolution_rate"], 0.5)
         mock_summary.assert_called_once()
 
-    def test_filters_only_ab2_projects(self, mock_summary):
+    def test_filters_only_ab2_inline_agent_switch_projects(self, mock_summary):
         mock_summary.return_value = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 1,
                     "resolved_count": 1,
                     "unresolved_count": 0,
@@ -207,7 +233,7 @@ class TestProjectsResolutionRateView(TestCase):
         )
         response = self._get(
             {
-                "project_uuids": f"{self.ab2_project.uuid},{self.ab25_project.uuid}",
+                "project_uuids": f"{self.eligible_project.uuid},{self.ab1_project.uuid}",
                 "start_date": "2026-05-19",
                 "end_date": "2026-05-25",
             }
@@ -215,15 +241,15 @@ class TestProjectsResolutionRateView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 1)
         called_uuids = mock_summary.call_args.kwargs["project_uuids"]
-        self.assertEqual(called_uuids, [str(self.ab2_project.uuid)])
+        self.assertEqual(called_uuids, [str(self.eligible_project.uuid)])
 
     def test_manager_fallback_when_missing(self, mock_summary):
-        self.ab2_project.manager_agent = None
-        self.ab2_project.save(update_fields=["manager_agent"])
+        self.eligible_project.manager_agent = None
+        self.eligible_project.save(update_fields=["manager_agent"])
         mock_summary.return_value = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 0,
                     "resolved_count": 0,
                     "unresolved_count": 0,
@@ -236,14 +262,14 @@ class TestProjectsResolutionRateView(TestCase):
                 }
             ]
         )
-        response = self._get({"project_uuids": str(self.ab2_project.uuid)})
+        response = self._get({"project_uuids": str(self.eligible_project.uuid)})
         self.assertEqual(response.data["results"][0]["manager"], "2.5")
 
     def test_include_limits_optional_blocks(self, mock_summary):
         mock_summary.return_value = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 1,
                     "resolved_count": 1,
                     "unresolved_count": 0,
@@ -258,7 +284,7 @@ class TestProjectsResolutionRateView(TestCase):
         )
         response = self._get(
             {
-                "project_uuids": str(self.ab2_project.uuid),
+                "project_uuids": str(self.eligible_project.uuid),
                 "include": "manager,agents",
             }
         )
@@ -272,14 +298,14 @@ class TestProjectsResolutionRateView(TestCase):
     def test_pagination_and_sorting(self, mock_summary):
         other = Project.objects.create(
             name="AAA Other",
-            org=self.ab2_project.org,
-            created_by=self.ab2_project.created_by,
-            agents_backend="BedrockBackend",
+            org=self.eligible_project.org,
+            created_by=self.eligible_project.created_by,
+            inline_agent_switch=True,
         )
         mock_summary.return_value = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 5,
                     "resolved_count": 2,
                     "unresolved_count": 0,
@@ -314,7 +340,7 @@ class TestProjectsResolutionRateView(TestCase):
         import requests
 
         mock_summary.side_effect = requests.ConnectionError("down")
-        response = self._get({"project_uuids": str(self.ab2_project.uuid)})
+        response = self._get({"project_uuids": str(self.eligible_project.uuid)})
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
 
     def test_conversations_http_502_returns_502(self, mock_summary):
@@ -323,14 +349,14 @@ class TestProjectsResolutionRateView(TestCase):
         exc = requests.HTTPError("bad gateway")
         exc.response = mock.Mock(status_code=status.HTTP_502_BAD_GATEWAY)
         mock_summary.side_effect = exc
-        response = self._get({"project_uuids": str(self.ab2_project.uuid)})
+        response = self._get({"project_uuids": str(self.eligible_project.uuid)})
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
 
     def test_page_size_over_100_is_truncated_in_response(self, mock_summary):
         mock_summary.return_value = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 1,
                     "resolved_count": 1,
                     "unresolved_count": 0,
@@ -345,7 +371,7 @@ class TestProjectsResolutionRateView(TestCase):
         )
         response = self._get(
             {
-                "project_uuids": str(self.ab2_project.uuid),
+                "project_uuids": str(self.eligible_project.uuid),
                 "page_size": "150",
             }
         )
@@ -355,14 +381,14 @@ class TestProjectsResolutionRateView(TestCase):
     def test_period_averages_stable_across_pages(self, mock_summary):
         other = Project.objects.create(
             name="ZZZ Other",
-            org=self.ab2_project.org,
-            created_by=self.ab2_project.created_by,
-            agents_backend="BedrockBackend",
+            org=self.eligible_project.org,
+            created_by=self.eligible_project.created_by,
+            inline_agent_switch=True,
         )
         summary = _summary_for_projects(
             [
                 {
-                    "project_uuid": str(self.ab2_project.uuid),
+                    "project_uuid": str(self.eligible_project.uuid),
                     "conversation_count": 1,
                     "resolved_count": 0,
                     "unresolved_count": 1,
@@ -423,8 +449,16 @@ class TestProjectsResolutionRateServiceHelpers(TestCase):
         with self.assertRaises(ValueError):
             parse_page_size("0")
 
+    def test_resolve_calendar_range_rejects_dates_before_go_live(self):
+        with self.assertRaises(ValueError) as ctx:
+            resolve_calendar_range(
+                parse_calendar_date("2026-03-27", "start_date"),
+                parse_calendar_date("2026-05-25", "end_date"),
+            )
+        self.assertIn(CONVERSATIONS_METRICS_EARLIEST_DATE.isoformat(), str(ctx.exception))
+
     def test_build_result_rows_handles_null_resolution_rate(self):
-        project = ProjectFactory(agents_backend="BedrockBackend")
+        project = ProjectFactory(inline_agent_switch=True)
         rows = build_result_rows(
             [project],
             {

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -16,6 +16,7 @@ from nexus.projects.models import Project
 from nexus.projects.services.projects_resolution_rate import (
     apply_include_blocks,
     build_result_rows,
+    parse_calendar_date,
     parse_page_size,
     sort_result_rows,
 )
@@ -412,6 +413,9 @@ class TestProjectsResolutionRateView(TestCase):
 
 
 class TestProjectsResolutionRateServiceHelpers(TestCase):
+    def test_parse_calendar_date_accepts_iso_date_string(self):
+        self.assertEqual(parse_calendar_date("2026-05-19", "start_date").isoformat(), "2026-05-19")
+
     def test_parse_page_size_truncates_above_100(self):
         self.assertEqual(parse_page_size("500"), 100)
 

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -15,10 +15,12 @@ from nexus.projects.api.resolution_rate_views import ProjectsResolutionRateView
 from nexus.projects.models import Project
 from nexus.projects.services.projects_resolution_rate import (
     apply_include_blocks,
+    build_result_rows,
     parse_page_size,
     sort_result_rows,
 )
 from nexus.usecases.intelligences.tests.intelligence_factory import IntegratedIntelligenceFactory
+from nexus.usecases.projects.tests.project_factory import ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
 
 SUMMARY_PAYLOAD = {
@@ -120,6 +122,12 @@ class TestProjectsResolutionRateView(TestCase):
     def test_partial_date_range_returns_400(self, mock_summary):
         response = self._get({"start_date": "2026-05-01"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_summary.assert_not_called()
+
+    def test_invalid_page_size_returns_400(self, mock_summary):
+        response = self._get({"project_uuids": str(self.ab2_project.uuid), "page_size": "0"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "page_size" in response.data
         mock_summary.assert_not_called()
 
     def test_success_merges_conversations_and_local_metadata(self, mock_summary):
@@ -299,6 +307,33 @@ class TestProjectsResolutionRateView(TestCase):
 class TestProjectsResolutionRateServiceHelpers(TestCase):
     def test_parse_page_size_truncates_above_100(self):
         self.assertEqual(parse_page_size("500"), 100)
+
+    def test_parse_page_size_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            parse_page_size("0")
+
+    def test_build_result_rows_handles_null_resolution_rate(self):
+        project = ProjectFactory(agents_backend="BedrockBackend")
+        rows = build_result_rows(
+            [project],
+            {
+                "projects": [
+                    {
+                        "project_uuid": str(project.uuid),
+                        "conversation_count": 2,
+                        "resolved_count": 1,
+                        "unresolved_count": 1,
+                        "human_support_count": 0,
+                        "resolution_rate": None,
+                        "csat": None,
+                        "csat_responses_count": 0,
+                        "nps": None,
+                        "nps_responses_count": 0,
+                    }
+                ]
+            },
+        )
+        self.assertEqual(rows[0]["resolution_rate"], 0.5)
 
     def test_sort_result_rows_orders_by_resolution_rate(self):
         rows = sort_result_rows(

--- a/nexus/projects/api/tests/test_projects_resolution_rate.py
+++ b/nexus/projects/api/tests/test_projects_resolution_rate.py
@@ -336,6 +336,56 @@ class TestProjectsResolutionRateView(TestCase):
         self.assertEqual(response.data["results"][0]["project_uuid"], str(other.uuid))
         self.assertEqual(response.data["average_resolution_rate"], 0.5)
 
+    def test_without_project_uuids_does_not_send_all_uuids_to_conversations(self, mock_summary):
+        inactive = Project.objects.create(
+            name="Inactive AB2",
+            org=self.eligible_project.org,
+            created_by=self.eligible_project.created_by,
+            inline_agent_switch=True,
+        )
+        mock_summary.return_value = _summary_for_projects(
+            [
+                {
+                    "project_uuid": str(self.eligible_project.uuid),
+                    "conversation_count": 3,
+                    "resolved_count": 1,
+                    "unresolved_count": 1,
+                    "human_support_count": 0,
+                    "resolution_rate": 0.3333,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                },
+                {
+                    "project_uuid": str(inactive.uuid),
+                    "conversation_count": 0,
+                    "resolved_count": 0,
+                    "unresolved_count": 0,
+                    "human_support_count": 0,
+                    "resolution_rate": 0.0,
+                    "csat": None,
+                    "csat_responses_count": 0,
+                    "nps": None,
+                    "nps_responses_count": 0,
+                },
+            ]
+        )
+        response = self._get(
+            {
+                "start_date": "2026-05-19",
+                "end_date": "2026-05-25",
+                "page": 1,
+                "page_size": 20,
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_summary.assert_called_once()
+        self.assertIsNone(mock_summary.call_args.kwargs["project_uuids"])
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["project_uuid"], str(self.eligible_project.uuid))
+
     def test_conversations_failure_returns_503(self, mock_summary):
         import requests
 

--- a/nexus/projects/services/projects_resolution_rate.py
+++ b/nexus/projects/services/projects_resolution_rate.py
@@ -182,6 +182,75 @@ def _metrics_by_project_uuid(summary_payload: dict[str, Any]) -> dict[str, dict[
     return {str(row["project_uuid"]): row for row in summary_payload.get("projects", [])}
 
 
+def _period_averages_from_metric_rows(project_metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    """Recompute period averages for a filtered project subset (FDD rules)."""
+    if not project_metrics:
+        return empty_summary_averages()
+
+    rates = [float(row.get("resolution_rate") or 0.0) for row in project_metrics]
+    average_resolution_rate = round(float(sum(rates) / len(rates)), 4)
+
+    csat_den = sum(int(row.get("csat_responses_count") or 0) for row in project_metrics)
+    csat_num = sum(
+        float(row["csat"]) * int(row["csat_responses_count"])
+        for row in project_metrics
+        if row.get("csat") is not None and int(row.get("csat_responses_count") or 0) > 0
+    )
+    nps_den = sum(int(row.get("nps_responses_count") or 0) for row in project_metrics)
+    nps_num = sum(
+        float(row["nps"]) * int(row["nps_responses_count"])
+        for row in project_metrics
+        if row.get("nps") is not None and int(row.get("nps_responses_count") or 0) > 0
+    )
+
+    return {
+        "average_resolution_rate": average_resolution_rate,
+        "average_csat": round(csat_num / csat_den, 4) if csat_den else None,
+        "average_nps": round(nps_num / nps_den, 4) if nps_den else None,
+    }
+
+
+def resolve_projects_for_response(
+    *,
+    query: ResolutionRateQuery,
+    summary_payload: dict[str, Any],
+    eligible_projects: list[Project],
+) -> tuple[list[Project], dict[str, Any]]:
+    """
+    When project_uuids are omitted, keep only eligible AB2 projects with conversations in range.
+    Recompute period averages for that filtered set.
+    """
+    if query.project_uuids is not None:
+        return eligible_projects, {
+            "average_resolution_rate": summary_payload.get("average_resolution_rate", 0.0),
+            "average_csat": summary_payload.get("average_csat"),
+            "average_nps": summary_payload.get("average_nps"),
+        }
+
+    metrics_map = _metrics_by_project_uuid(summary_payload)
+    eligible_by_uuid = {str(project.uuid): project for project in eligible_projects}
+    active_metrics: list[dict[str, Any]] = []
+    active_projects: list[Project] = []
+
+    for project_uuid, project in eligible_by_uuid.items():
+        metrics = metrics_map.get(project_uuid)
+        if not metrics:
+            continue
+        if int(metrics.get("conversation_count") or 0) < 1:
+            continue
+        active_metrics.append(metrics)
+        active_projects.append(project)
+
+    return active_projects, _period_averages_from_metric_rows(active_metrics)
+
+
+def conversations_fetch_project_uuids(query: ResolutionRateQuery, eligible_projects: list[Project]) -> list[str] | None:
+    """Omit UUID list when the client did not filter by project (avoids oversized query strings)."""
+    if query.project_uuids is None:
+        return None
+    return [str(project.uuid) for project in eligible_projects]
+
+
 def _resolution_rate_from_metrics(
     metrics: dict[str, Any],
     *,
@@ -302,6 +371,7 @@ def build_response(
     query: ResolutionRateQuery,
     summary_payload: dict[str, Any],
     projects: list[Project],
+    period_averages: dict[str, Any],
 ) -> dict[str, Any]:
     start_date, end_date = _response_dates(query, summary_payload)
 
@@ -326,9 +396,7 @@ def build_response(
         "page_size": query.page_size,
         "start_date": start_date,
         "end_date": end_date,
-        "average_resolution_rate": summary_payload.get("average_resolution_rate", 0.0),
-        "average_csat": summary_payload.get("average_csat"),
-        "average_nps": summary_payload.get("average_nps"),
+        **period_averages,
         "results": results,
     }
 

--- a/nexus/projects/services/projects_resolution_rate.py
+++ b/nexus/projects/services/projects_resolution_rate.py
@@ -52,9 +52,12 @@ class ResolutionRateQuery:
 
 def parse_calendar_date(value: str, field_name: str) -> pendulum.Date:
     try:
-        return pendulum.parse(str(value).strip(), exact=True).date()
+        parsed = pendulum.parse(str(value).strip(), exact=True)
     except Exception as e:
         raise ValueError(f"Invalid {field_name} format. Use YYYY-MM-DD") from e
+    if isinstance(parsed, pendulum.Date):
+        return parsed
+    return parsed.date()
 
 
 def parse_project_uuids(raw_values: list[str]) -> list[UUID]:

--- a/nexus/projects/services/projects_resolution_rate.py
+++ b/nexus/projects/services/projects_resolution_rate.py
@@ -1,0 +1,304 @@
+"""Orchestrate projects resolution-rate from nexus-conversations and local project metadata."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import pendulum
+from django.db.models import Count, Q
+
+from nexus.inline_agents.models import Agent
+from nexus.projects.models import Project
+
+logger = logging.getLogger(__name__)
+
+AB2_BACKEND = "BedrockBackend"
+MANAGER_FALLBACK = "2.5"
+
+OPTIONAL_INCLUDE_BLOCKS = frozenset(
+    {
+        "conversations",
+        "csat",
+        "nps",
+        "manager",
+        "agents",
+        "components",
+    }
+)
+
+CONVERSATION_METRIC_FIELDS = (
+    "conversation_count",
+    "resolved_count",
+    "unresolved_count",
+    "human_support_count",
+)
+CSAT_FIELDS = ("csat", "csat_responses_count")
+NPS_FIELDS = ("nps", "nps_responses_count")
+AGENT_FIELDS = ("agents_count", "official_agents_count")
+
+
+@dataclass(frozen=True)
+class ResolutionRateQuery:
+    project_uuids: list[UUID] | None
+    start_date: pendulum.Date | None
+    end_date: pendulum.Date | None
+    page: int
+    page_size: int
+    include_blocks: set[str] | None
+
+
+def parse_calendar_date(value: str, field_name: str) -> pendulum.Date:
+    try:
+        return pendulum.parse(str(value).strip(), exact=True).date()
+    except Exception as e:
+        raise ValueError(f"Invalid {field_name} format. Use YYYY-MM-DD") from e
+
+
+def parse_project_uuids(raw_values: list[str]) -> list[UUID]:
+    if not raw_values:
+        return []
+    uuids: list[UUID] = []
+    seen: set[UUID] = set()
+    for raw in raw_values:
+        for part in str(raw).split(","):
+            token = part.strip()
+            if not token:
+                continue
+            try:
+                parsed = UUID(token)
+            except ValueError as e:
+                raise ValueError(f"Invalid project UUID: {token}") from e
+            if parsed not in seen:
+                seen.add(parsed)
+                uuids.append(parsed)
+    return uuids
+
+
+def parse_page(value: str | None, default: int = 1) -> int:
+    if value is None or str(value).strip() == "":
+        return default
+    try:
+        page = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError("page must be a positive integer") from e
+    if page < 1:
+        raise ValueError("page must be a positive integer")
+    return page
+
+
+def parse_page_size(value: str | None, default: int = 20, maximum: int = 100) -> int:
+    if value is None or str(value).strip() == "":
+        return default
+    try:
+        size = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError("page_size must be a positive integer") from e
+    if size < 1:
+        return default
+    return min(size, maximum)
+
+
+def parse_include_blocks(raw: str | None) -> set[str] | None:
+    if raw is None or not str(raw).strip():
+        return None
+    blocks = {part.strip().lower() for part in str(raw).split(",") if part.strip()}
+    unknown = blocks - OPTIONAL_INCLUDE_BLOCKS
+    if unknown:
+        raise ValueError(f"Invalid include values: {', '.join(sorted(unknown))}")
+    return blocks
+
+
+def resolve_calendar_range(
+    start_date: pendulum.Date | None,
+    end_date: pendulum.Date | None,
+) -> tuple[pendulum.Date | None, pendulum.Date | None]:
+    if start_date is None and end_date is None:
+        return None, None
+    if start_date is None or end_date is None:
+        raise ValueError("start_date and end_date must both be provided or both omitted")
+    if start_date > end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+    return start_date, end_date
+
+
+def eligible_projects_queryset(project_uuids: list[UUID] | None):
+    qs = Project.objects.filter(is_active=True, agents_backend=AB2_BACKEND).select_related("manager_agent")
+    if project_uuids:
+        qs = qs.filter(uuid__in=project_uuids)
+    return qs.order_by("name")
+
+
+def _manager_name(project: Project) -> str:
+    manager = project.manager_agent
+    if manager and manager.name:
+        return manager.name
+    return MANAGER_FALLBACK
+
+
+def _agent_counts(projects: list[Project]) -> dict[UUID, dict[str, int]]:
+    if not projects:
+        return {}
+    rows = (
+        Agent.objects.filter(project__in=projects)
+        .values("project_id")
+        .annotate(
+            agents_count=Count("uuid"),
+            official_agents_count=Count("uuid", filter=Q(is_official=True)),
+        )
+    )
+    return {
+        row["project_id"]: {
+            "agents_count": int(row["agents_count"] or 0),
+            "official_agents_count": int(row["official_agents_count"] or 0),
+        }
+        for row in rows
+    }
+
+
+def _metrics_by_project_uuid(summary_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(row["project_uuid"]): row for row in summary_payload.get("projects", [])}
+
+
+def build_result_rows(
+    projects: list[Project],
+    summary_payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    metrics_map = _metrics_by_project_uuid(summary_payload)
+    agent_map = _agent_counts(projects)
+    rows: list[dict[str, Any]] = []
+
+    for project in projects:
+        metrics = metrics_map.get(str(project.uuid), {})
+        agent_row = agent_map.get(project.uuid, {"agents_count": 0, "official_agents_count": 0})
+        conversation_count = int(metrics.get("conversation_count") or 0)
+        resolved_count = int(metrics.get("resolved_count") or 0)
+        resolution_rate = float(metrics.get("resolution_rate", 0.0))
+        if conversation_count > 0 and "resolution_rate" not in metrics:
+            resolution_rate = resolved_count / conversation_count
+
+        rows.append(
+            {
+                "project_uuid": str(project.uuid),
+                "project_name": project.name,
+                "resolution_rate": round(resolution_rate, 4),
+                "conversation_count": conversation_count,
+                "resolved_count": resolved_count,
+                "unresolved_count": int(metrics.get("unresolved_count") or 0),
+                "human_support_count": int(metrics.get("human_support_count") or 0),
+                "csat": metrics.get("csat"),
+                "csat_responses_count": int(metrics.get("csat_responses_count") or 0),
+                "nps": metrics.get("nps"),
+                "nps_responses_count": int(metrics.get("nps_responses_count") or 0),
+                "manager": _manager_name(project),
+                "uses_components": bool(project.use_components),
+                "agents_count": agent_row["agents_count"],
+                "official_agents_count": agent_row["official_agents_count"],
+            }
+        )
+    return rows
+
+
+def sort_result_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        rows,
+        key=lambda row: (
+            -float(row["resolution_rate"]),
+            -int(row.get("conversation_count") or 0),
+            str(row.get("project_name") or "").lower(),
+        ),
+    )
+
+
+def apply_include_blocks(row: dict[str, Any], include_blocks: set[str] | None) -> dict[str, Any]:
+    if include_blocks is None:
+        return row
+
+    filtered = {
+        "project_uuid": row["project_uuid"],
+        "project_name": row["project_name"],
+        "resolution_rate": row["resolution_rate"],
+    }
+    if "conversations" in include_blocks:
+        for field in CONVERSATION_METRIC_FIELDS:
+            filtered[field] = row[field]
+    if "csat" in include_blocks:
+        for field in CSAT_FIELDS:
+            filtered[field] = row[field]
+    if "nps" in include_blocks:
+        for field in NPS_FIELDS:
+            filtered[field] = row[field]
+    if "manager" in include_blocks:
+        filtered["manager"] = row["manager"]
+    if "components" in include_blocks:
+        filtered["uses_components"] = row["uses_components"]
+    if "agents" in include_blocks:
+        for field in AGENT_FIELDS:
+            filtered[field] = row[field]
+    return filtered
+
+
+def paginate_rows(rows: list[dict[str, Any]], page: int, page_size: int) -> tuple[list[dict[str, Any]], int]:
+    total = len(rows)
+    offset = (page - 1) * page_size
+    return rows[offset : offset + page_size], total
+
+
+def empty_summary_averages() -> dict[str, Any]:
+    return {
+        "average_resolution_rate": 0.0,
+        "average_csat": None,
+        "average_nps": None,
+    }
+
+
+def build_response(
+    *,
+    query: ResolutionRateQuery,
+    summary_payload: dict[str, Any],
+    projects: list[Project],
+) -> dict[str, Any]:
+    if not projects:
+        return {
+            "count": 0,
+            "page": query.page,
+            "page_size": query.page_size,
+            "start_date": query.start_date.isoformat() if query.start_date else None,
+            "end_date": query.end_date.isoformat() if query.end_date else None,
+            **empty_summary_averages(),
+            "results": [],
+        }
+
+    rows = sort_result_rows(build_result_rows(projects, summary_payload))
+    page_rows, count = paginate_rows(rows, query.page, query.page_size)
+    results = [apply_include_blocks(row, query.include_blocks) for row in page_rows]
+
+    return {
+        "count": count,
+        "page": query.page,
+        "page_size": query.page_size,
+        "start_date": summary_payload.get("start_date"),
+        "end_date": summary_payload.get("end_date"),
+        "average_resolution_rate": summary_payload.get("average_resolution_rate", 0.0),
+        "average_csat": summary_payload.get("average_csat"),
+        "average_nps": summary_payload.get("average_nps"),
+        "results": results,
+    }
+
+
+def log_conversations_failure(
+    *,
+    project_uuids: list[str],
+    start_date: str | None,
+    end_date: str | None,
+    exc: Exception,
+) -> None:
+    logger.exception(
+        "[projects_resolution_rate] nexus-conversations request failed project_count=%s start_date=%s end_date=%s",
+        len(project_uuids),
+        start_date,
+        end_date,
+        exc_info=exc,
+    )

--- a/nexus/projects/services/projects_resolution_rate.py
+++ b/nexus/projects/services/projects_resolution_rate.py
@@ -97,7 +97,7 @@ def parse_page_size(value: str | None, default: int = 20, maximum: int = 100) ->
     except (TypeError, ValueError) as e:
         raise ValueError("page_size must be a positive integer") from e
     if size < 1:
-        return default
+        raise ValueError("page_size must be a positive integer")
     return min(size, maximum)
 
 
@@ -162,6 +162,27 @@ def _metrics_by_project_uuid(summary_payload: dict[str, Any]) -> dict[str, dict[
     return {str(row["project_uuid"]): row for row in summary_payload.get("projects", [])}
 
 
+def _resolution_rate_from_metrics(
+    metrics: dict[str, Any],
+    *,
+    conversation_count: int,
+    resolved_count: int,
+) -> float:
+    raw = metrics.get("resolution_rate")
+    if raw is None:
+        return float(resolved_count / conversation_count) if conversation_count > 0 else 0.0
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return float(resolved_count / conversation_count) if conversation_count > 0 else 0.0
+
+
+def _response_dates(query: ResolutionRateQuery, summary_payload: dict[str, Any]) -> tuple[Any, Any]:
+    start_date = query.start_date.isoformat() if query.start_date else summary_payload.get("start_date")
+    end_date = query.end_date.isoformat() if query.end_date else summary_payload.get("end_date")
+    return start_date, end_date
+
+
 def build_result_rows(
     projects: list[Project],
     summary_payload: dict[str, Any],
@@ -175,9 +196,11 @@ def build_result_rows(
         agent_row = agent_map.get(project.uuid, {"agents_count": 0, "official_agents_count": 0})
         conversation_count = int(metrics.get("conversation_count") or 0)
         resolved_count = int(metrics.get("resolved_count") or 0)
-        resolution_rate = float(metrics.get("resolution_rate", 0.0))
-        if conversation_count > 0 and "resolution_rate" not in metrics:
-            resolution_rate = resolved_count / conversation_count
+        resolution_rate = _resolution_rate_from_metrics(
+            metrics,
+            conversation_count=conversation_count,
+            resolved_count=resolved_count,
+        )
 
         rows.append(
             {
@@ -260,13 +283,15 @@ def build_response(
     summary_payload: dict[str, Any],
     projects: list[Project],
 ) -> dict[str, Any]:
+    start_date, end_date = _response_dates(query, summary_payload)
+
     if not projects:
         return {
             "count": 0,
             "page": query.page,
             "page_size": query.page_size,
-            "start_date": query.start_date.isoformat() if query.start_date else None,
-            "end_date": query.end_date.isoformat() if query.end_date else None,
+            "start_date": start_date,
+            "end_date": end_date,
             **empty_summary_averages(),
             "results": [],
         }
@@ -279,8 +304,8 @@ def build_response(
         "count": count,
         "page": query.page,
         "page_size": query.page_size,
-        "start_date": summary_payload.get("start_date"),
-        "end_date": summary_payload.get("end_date"),
+        "start_date": start_date,
+        "end_date": end_date,
         "average_resolution_rate": summary_payload.get("average_resolution_rate", 0.0),
         "average_csat": summary_payload.get("average_csat"),
         "average_nps": summary_payload.get("average_nps"),
@@ -295,10 +320,10 @@ def log_conversations_failure(
     end_date: str | None,
     exc: Exception,
 ) -> None:
-    logger.exception(
+    logger.error(
         "[projects_resolution_rate] nexus-conversations request failed project_count=%s start_date=%s end_date=%s",
         len(project_uuids),
         start_date,
         end_date,
-        exc_info=exc,
+        exc_info=(type(exc), exc, exc.__traceback__),
     )

--- a/nexus/projects/services/projects_resolution_rate.py
+++ b/nexus/projects/services/projects_resolution_rate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import date
 from typing import Any
 from uuid import UUID
 
@@ -15,7 +16,7 @@ from nexus.projects.models import Project
 
 logger = logging.getLogger(__name__)
 
-AB2_BACKEND = "BedrockBackend"
+CONVERSATIONS_METRICS_EARLIEST_DATE = date(2026, 3, 28)
 MANAGER_FALLBACK = "2.5"
 
 OPTIONAL_INCLUDE_BLOCKS = frozenset(
@@ -114,6 +115,19 @@ def parse_include_blocks(raw: str | None) -> set[str] | None:
     return blocks
 
 
+def _calendar_date_to_date(value: pendulum.Date) -> date:
+    return date(value.year, value.month, value.day)
+
+
+def _validate_metrics_earliest_date(field_name: str, value: pendulum.Date) -> None:
+    day = _calendar_date_to_date(value)
+    if day < CONVERSATIONS_METRICS_EARLIEST_DATE:
+        raise ValueError(
+            f"{field_name} must be on or after {CONVERSATIONS_METRICS_EARLIEST_DATE.isoformat()} "
+            "(conversations metrics are only available from that date)"
+        )
+
+
 def resolve_calendar_range(
     start_date: pendulum.Date | None,
     end_date: pendulum.Date | None,
@@ -122,13 +136,16 @@ def resolve_calendar_range(
         return None, None
     if start_date is None or end_date is None:
         raise ValueError("start_date and end_date must both be provided or both omitted")
+    _validate_metrics_earliest_date("start_date", start_date)
+    _validate_metrics_earliest_date("end_date", end_date)
     if start_date > end_date:
         raise ValueError("start_date must be before or equal to end_date")
     return start_date, end_date
 
 
 def eligible_projects_queryset(project_uuids: list[UUID] | None):
-    qs = Project.objects.filter(is_active=True, agents_backend=AB2_BACKEND).select_related("manager_agent")
+    """AB 2 projects only: inline_agent_switch=True (AB 1 uses inline_agent_switch=False)."""
+    qs = Project.objects.filter(is_active=True, inline_agent_switch=True).select_related("manager_agent")
     if project_uuids:
         qs = qs.filter(uuid__in=project_uuids)
     return qs.order_by("name")

--- a/nexus/projects/services/projects_resolution_rate.py
+++ b/nexus/projects/services/projects_resolution_rate.py
@@ -321,9 +321,11 @@ def log_conversations_failure(
     exc: Exception,
 ) -> None:
     logger.error(
-        "[projects_resolution_rate] nexus-conversations request failed project_count=%s start_date=%s end_date=%s",
+        "[projects_resolution_rate] nexus-conversations request failed "
+        "project_count=%s start_date=%s end_date=%s sample_project_uuids=%s",
         len(project_uuids),
         start_date,
         end_date,
+        project_uuids[:5],
         exc_info=(type(exc), exc, exc.__traceback__),
     )


### PR DESCRIPTION
Introduced a new internal API endpoint for retrieving aggregated resolution, CSAT, and NPS metrics for multiple projects. This includes a new view, serializers, and service functions to handle the data processing and response formatting. The endpoint allows filtering by project UUIDs and date ranges, enhancing the analytics capabilities for project performance metrics.