### PR TITLE
feat: enhance agent credential handling in my-agents endpoint

### DIFF
--- a/nexus/agents/api/test_agents_api.py
+++ b/nexus/agents/api/test_agents_api.py
@@ -12,6 +12,7 @@ from nexus.agents.api.views import InternalCommunicationPermission
 from nexus.agents.models import Team
 from nexus.inline_agents.models import (
     MCP,
+    AgentCredential,
     AgentGroup,
     AgentGroupModal,
     AgentSystem,
@@ -197,6 +198,79 @@ class AgentViewsetSetTestCase(TestCase):
         self.assertEqual(mcp_payload["config"][0]["name"], "REGION_TOGGLE")
         self.assertEqual(len(mcp_payload["credentials"]), 1)
         self.assertEqual(mcp_payload["credentials"][0]["name"], "SYNERISE_API_TOKEN")
+
+    def test_get_my_agents_includes_agent_credentials_in_mcps_without_linked_mcp(self):
+        agent_with_credentials = InlineAgent.objects.create(
+            name="VTEX Orders Agent",
+            slug="vtex-orders-cred-test-xyz",
+            instruction="x",
+            collaboration_instructions="Consulta pedidos VTEX",
+            foundation_model="model:version",
+            project=self.project,
+        )
+        for key, label, is_confidential in (
+            ("vtex_app_key", "VTEX App Key", True),
+            ("vtex_account", "Conta VTEX", False),
+        ):
+            credential = AgentCredential.objects.create(
+                project=self.project,
+                key=key,
+                label=label,
+                placeholder=f"placeholder-{key}",
+                is_confidential=is_confidential,
+            )
+            credential.agents.add(agent_with_credentials)
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("my-agents", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        response.render()
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        row = next(c for c in content if c.get("uuid") == str(agent_with_credentials.uuid))
+        self.assertEqual(len(row["mcps"]), 1)
+        mcp_payload = row["mcps"][0]
+        self.assertIsNone(mcp_payload["name"])
+        self.assertEqual(mcp_payload["system"], None)
+        self.assertEqual(mcp_payload["config"], [])
+        cred_names = {c["name"] for c in mcp_payload["credentials"]}
+        self.assertEqual(cred_names, {"vtex_app_key", "vtex_account"})
+        by_name = {c["name"]: c for c in mcp_payload["credentials"]}
+        self.assertEqual(by_name["vtex_app_key"]["label"], "VTEX App Key")
+        self.assertTrue(by_name["vtex_app_key"]["is_confidential"])
+
+    def test_get_my_agents_merges_agent_credentials_when_mcp_templates_empty(self):
+        system = AgentSystem.objects.create(name="VTEX System", slug="vtex-system-cred-merge-xyz")
+        mcp = MCP.objects.create(name="VTEX MCP", slug="vtex-mcp-cred-merge-xyz", system=system)
+        agent = InlineAgent.objects.create(
+            name="Agent MCP merge",
+            slug="agent-mcp-cred-merge-xyz",
+            instruction="x",
+            collaboration_instructions="y",
+            foundation_model="model:version",
+            project=self.project,
+        )
+        agent.mcps.add(mcp)
+        credential = AgentCredential.objects.create(
+            project=self.project,
+            key="vtex_app_token",
+            label="VTEX App Token",
+            placeholder="token",
+            is_confidential=True,
+        )
+        credential.agents.add(agent)
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("my-agents", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        response.render()
+        content = json.loads(response.content)
+        row = next(c for c in content if c.get("uuid") == str(agent.uuid))
+        self.assertEqual(len(row["mcps"]), 1)
+        cred_names = {c["name"] for c in row["mcps"][0]["credentials"]}
+        self.assertEqual(cred_names, {"vtex_app_token"})
 
 
 class TeamViewsetSetTestCase(TestCase):

--- a/nexus/inline_agents/admin.py
+++ b/nexus/inline_agents/admin.py
@@ -18,6 +18,7 @@ from nexus.inline_agents.models import (
     MCP,
     Agent,
     AgentCategory,
+    AgentCredential,
     AgentGroup,
     AgentGroupModal,
     AgentSystem,
@@ -209,6 +210,43 @@ class VersionInline(admin.TabularInline):
         return qs.order_by("-created_on")
 
 
+class AgentCredentialInline(admin.TabularInline):
+    """Read-only list of AgentCredential entries linked to this Agent."""
+
+    model = AgentCredential.agents.through
+    extra = 0
+    can_delete = False
+    show_change_link = False
+    verbose_name = "Credential"
+    verbose_name_plural = "Credentials"
+    fields = ("credential_key", "credential_label", "credential_placeholder", "credential_is_confidential", "view_link")
+    readonly_fields = fields
+
+    def credential_key(self, obj):
+        return getattr(obj.agentcredential, "key", None)
+
+    def credential_label(self, obj):
+        return getattr(obj.agentcredential, "label", None)
+
+    def credential_placeholder(self, obj):
+        return getattr(obj.agentcredential, "placeholder", None)
+
+    def credential_is_confidential(self, obj):
+        return getattr(obj.agentcredential, "is_confidential", None)
+
+    def view_link(self, obj):
+        if getattr(obj, "agentcredential_id", None):
+            url = reverse("admin:inline_agents_agentcredential_change", args=[obj.agentcredential_id])
+            return format_html('<a href="{}" target="_blank">View</a>', url)
+        return "-"
+
+    credential_key.short_description = "Key"
+    credential_label.short_description = "Label"
+    credential_placeholder.short_description = "Placeholder"
+    credential_is_confidential.short_description = "Confidential"
+    view_link.short_description = "Actions"
+
+
 @admin.register(Version)
 class VersionAdmin(admin.ModelAdmin):
     """Admin interface for Version model - shows skills and display_skills"""
@@ -237,7 +275,7 @@ class AgentAdmin(admin.ModelAdmin):
     search_fields = ("name", "project__name", "project__uuid", "slug", "uuid")
     ordering = ("project__name",)
     autocomplete_fields = ["project", "group", "systems", "agent_type", "category", "mcps"]
-    inlines = [VersionInline]
+    inlines = [VersionInline, AgentCredentialInline]
     readonly_fields = ("mcps_list",)
 
     fieldsets = (
@@ -350,6 +388,16 @@ class AgentAdmin(admin.ModelAdmin):
         return format_html(html)
 
     mcps_list.short_description = "Associated MCPs"
+
+
+@admin.register(AgentCredential)
+class AgentCredentialAdmin(admin.ModelAdmin):
+    list_display = ("key", "label", "project", "is_confidential")
+    list_filter = ("is_confidential",)
+    search_fields = ("key", "label", "project__name", "project__uuid")
+    ordering = ("project__name", "key")
+    autocomplete_fields = ["project", "agents"]
+    readonly_fields = ()
 
 
 class AgentGroupModalInline(admin.StackedInline):

--- a/nexus/inline_agents/api/serializers/catalog.py
+++ b/nexus/inline_agents/api/serializers/catalog.py
@@ -13,7 +13,7 @@ from nexus.inline_agents.api.official_agents_helpers import (
     get_all_mcps_for_group,
     get_all_systems_for_group,
 )
-from nexus.inline_agents.models import Agent, IntegratedAgent
+from nexus.inline_agents.models import Agent, AgentCredential, IntegratedAgent
 
 # Canonical catalog row (novo retorno) — same keys on every list surface.
 # Official v1: one row per ``AgentGroup`` (group view). My-agents / project official: one row per ``Agent``.
@@ -126,13 +126,68 @@ def _flatten_group_mcps(group_slug: str) -> list[dict[str, Any]]:
     return _sort_mcps(out)
 
 
+def _serialize_agent_credential(credential: AgentCredential) -> dict[str, Any]:
+    """Same shape as ``_serialize_mcp`` credential templates (schema only, no values)."""
+    return {
+        "name": credential.key,
+        "label": credential.label,
+        "placeholder": credential.placeholder,
+        "is_confidential": credential.is_confidential,
+    }
+
+
+def _agent_credentials_payload(agent: Agent) -> list[dict[str, Any]]:
+    seen_keys: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    for credential in agent.agentcredential_set.all().order_by("key"):
+        key = credential.key
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        rows.append(_serialize_agent_credential(credential))
+    return rows
+
+
+def _merge_agent_credentials_into_mcp(mcp_data: dict[str, Any], agent_credentials: list[dict[str, Any]]) -> None:
+    """Fill ``mcp_data['credentials']`` from agent credentials when MCP templates are missing or partial."""
+    if not agent_credentials:
+        return
+    if not mcp_data.get("credentials"):
+        mcp_data["credentials"] = list(agent_credentials)
+        return
+    existing_names = {item["name"] for item in mcp_data["credentials"]}
+    for credential in agent_credentials:
+        if credential["name"] not in existing_names:
+            mcp_data["credentials"].append(credential)
+
+
+def _synthetic_mcp_for_agent_credentials(agent: Agent, credentials: list[dict[str, Any]]) -> dict[str, Any]:
+    """Carrier row for ``mcps[].credentials`` when the agent has no linked MCP (not a DB MCP)."""
+    description = (agent.collaboration_instructions or "").strip() or None
+    return {
+        "name": None,
+        "description": {"en": description, "pt": None, "es": None},
+        "system": None,
+        "config": [],
+        "credentials": credentials,
+    }
+
+
 def _mcps_for_standalone_agent(agent: Agent) -> list[dict[str, Any]]:
+    agent_credentials = _agent_credentials_payload(agent)
     mcps = (
         agent.mcps.filter(is_active=True)
         .select_related("system")
         .prefetch_related("config_options", "credential_templates")
     )
-    return _sort_mcps([_serialize_mcp(m) for m in mcps])
+    serialized = [_serialize_mcp(m) for m in mcps]
+    if serialized:
+        for mcp_data in serialized:
+            _merge_agent_credentials_into_mcp(mcp_data, agent_credentials)
+        return _sort_mcps(serialized)
+    if agent_credentials:
+        return [_synthetic_mcp_for_agent_credentials(agent, agent_credentials)]
+    return []
 
 
 def _mcps_for_agent(agent: Agent, group_slug: str | None) -> list[dict[str, Any]]:

--- a/nexus/inline_agents/api/serializers/catalog.py
+++ b/nexus/inline_agents/api/serializers/catalog.py
@@ -4,6 +4,7 @@ from itertools import groupby
 from typing import Any
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Prefetch
 
 from nexus.inline_agents.api.official_agents_helpers import (
     _serialize_mcp,
@@ -13,7 +14,26 @@ from nexus.inline_agents.api.official_agents_helpers import (
     get_all_mcps_for_group,
     get_all_systems_for_group,
 )
-from nexus.inline_agents.models import Agent, AgentCredential, IntegratedAgent
+from nexus.inline_agents.models import MCP, Agent, AgentCredential, IntegratedAgent
+
+
+def my_agents_list_prefetches() -> list:
+    """Prefetch plan for ``AgentsView`` — must match ``_agent_credentials_payload`` / ``_mcps_for_standalone_agent``."""
+    return [
+        "systems",
+        Prefetch(
+            "agentcredential_set",
+            queryset=AgentCredential.objects.order_by("key"),
+        ),
+        Prefetch(
+            "mcps",
+            queryset=MCP.objects.filter(is_active=True)
+            .select_related("system")
+            .prefetch_related("config_options", "credential_templates")
+            .order_by("order", "name"),
+        ),
+    ]
+
 
 # Canonical catalog row (novo retorno) — same keys on every list surface.
 # Official v1: one row per ``AgentGroup`` (group view). My-agents / project official: one row per ``Agent``.
@@ -136,10 +156,31 @@ def _serialize_agent_credential(credential: AgentCredential) -> dict[str, Any]:
     }
 
 
+def _iter_agent_credentials(agent: Agent) -> list[AgentCredential]:
+    """Use prefetched credentials when present; avoid ``.order_by()`` on the related manager (N+1)."""
+    cache = getattr(agent, "_prefetched_objects_cache", None)
+    if isinstance(cache, dict) and "agentcredential_set" in cache:
+        return sorted(cache["agentcredential_set"], key=lambda credential: credential.key or "")
+    return list(agent.agentcredential_set.all().order_by("key"))
+
+
+def _iter_active_agent_mcps(agent: Agent) -> list[MCP]:
+    """Use prefetched active MCPs when present; otherwise fall back to a filtered queryset."""
+    cache = getattr(agent, "_prefetched_objects_cache", None)
+    if isinstance(cache, dict) and "mcps" in cache:
+        return list(cache["mcps"])
+    return list(
+        agent.mcps.filter(is_active=True)
+        .select_related("system")
+        .prefetch_related("config_options", "credential_templates")
+        .order_by("order", "name")
+    )
+
+
 def _agent_credentials_payload(agent: Agent) -> list[dict[str, Any]]:
     seen_keys: set[str] = set()
     rows: list[dict[str, Any]] = []
-    for credential in agent.agentcredential_set.all().order_by("key"):
+    for credential in _iter_agent_credentials(agent):
         key = credential.key
         if not key or key in seen_keys:
             continue
@@ -175,12 +216,7 @@ def _synthetic_mcp_for_agent_credentials(agent: Agent, credentials: list[dict[st
 
 def _mcps_for_standalone_agent(agent: Agent) -> list[dict[str, Any]]:
     agent_credentials = _agent_credentials_payload(agent)
-    mcps = (
-        agent.mcps.filter(is_active=True)
-        .select_related("system")
-        .prefetch_related("config_options", "credential_templates")
-    )
-    serialized = [_serialize_mcp(m) for m in mcps]
+    serialized = [_serialize_mcp(m) for m in _iter_active_agent_mcps(agent)]
     if serialized:
         for mcp_data in serialized:
             _merge_agent_credentials_into_mcp(mcp_data, agent_credentials)

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -28,6 +28,7 @@ from nexus.inline_agents.api.serializers import (
 )
 from nexus.inline_agents.api.serializers.catalog import (
     build_row_from_project_agent,
+    my_agents_list_prefetches,
     project_agent_assignment_map,
 )
 from nexus.inline_agents.api.services.official_catalog import (
@@ -693,12 +694,7 @@ class AgentsView(APIView):
             )
             agents = agents.filter(query_filter).distinct("uuid")
 
-        agents = agents.prefetch_related(
-            "systems",
-            "agentcredential_set",
-            "mcps__config_options",
-            "mcps__credential_templates",
-        )
+        agents = agents.prefetch_related(*my_agents_list_prefetches())
         assignment = (
             project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
         )

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -693,7 +693,12 @@ class AgentsView(APIView):
             )
             agents = agents.filter(query_filter).distinct("uuid")
 
-        agents = agents.prefetch_related("systems")
+        agents = agents.prefetch_related(
+            "systems",
+            "agentcredential_set",
+            "mcps__config_options",
+            "mcps__credential_templates",
+        )
         assignment = (
             project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
         )

--- a/nexus/inline_agents/tests.py
+++ b/nexus/inline_agents/tests.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils.datastructures import MultiValueDict
 from rest_framework.test import APIClient
 
+from nexus.agents.encryption import encrypt_value
 from nexus.inline_agents.api.serializers import ProjectCredentialsListSerializer
 from nexus.inline_agents.models import MCP, Agent, AgentCredential, AgentSystem, IntegratedAgent
 from nexus.usecases.inline_agents.assign import AssignAgentsUsecase
@@ -98,6 +99,58 @@ class TestAgentsUsecase(TestCase):
         deleted, integrated_agent = self.usecase.unassign_agent(self.agent.uuid, self.project.uuid)
         self.assertFalse(deleted)
         self.assertIsNone(integrated_agent)
+
+    def test_unassign_agent_preserves_credentials_and_clears_values(self):
+        credential = AgentCredential.objects.create(
+            key="vtex_app_key",
+            label="VTEX App Key",
+            placeholder="vtexappkey-example",
+            is_confidential=True,
+            value=encrypt_value("secret-key"),
+            project=self.project,
+        )
+        credential.agents.add(self.agent)
+
+        self.usecase.assign_agent(self.agent.uuid, self.project.uuid)
+        deleted, _ = self.usecase.unassign_agent(self.agent.uuid, self.project.uuid)
+
+        self.assertTrue(deleted)
+        self.assertFalse(IntegratedAgent.objects.filter(agent=self.agent, project=self.project).exists())
+        credential.refresh_from_db()
+        self.assertEqual(credential.value, "")
+        self.assertTrue(credential.agents.filter(pk=self.agent.pk).exists())
+
+    def test_unassign_agent_does_not_clear_shared_credential_while_other_agent_assigned(self):
+        other_agent = Agent.objects.create(
+            name="Other Agent",
+            slug="other-agent",
+            collaboration_instructions="Lorem Ipsum dolor sit amet",
+            project=self.project,
+            instruction="Lorem Ipsum dolor sit amet",
+            foundation_model="claude",
+        )
+        other_agent.versions.create(skills=[], display_skills=[])
+
+        credential = AgentCredential.objects.create(
+            key="shared_api_key",
+            label="Shared API Key",
+            placeholder="your-api-key-here",
+            is_confidential=True,
+            value=encrypt_value("shared-secret"),
+            project=self.project,
+        )
+        credential.agents.add(self.agent, other_agent)
+
+        self.usecase.assign_agent(self.agent.uuid, self.project.uuid)
+        self.usecase.assign_agent(other_agent.uuid, self.project.uuid)
+        original_value = credential.value
+
+        self.usecase.unassign_agent(self.agent.uuid, self.project.uuid)
+
+        credential.refresh_from_db()
+        self.assertEqual(credential.value, original_value)
+        self.assertTrue(credential.agents.filter(pk=self.agent.pk).exists())
+        self.assertTrue(IntegratedAgent.objects.filter(agent=other_agent, project=self.project).exists())
 
     def test_set_agent_active_activate(self):
         self.usecase.assign_agent(self.agent.uuid, self.project.uuid)

--- a/nexus/usecases/inline_agents/assign.py
+++ b/nexus/usecases/inline_agents/assign.py
@@ -41,6 +41,19 @@ def resolve_assignment_mcp_fields(
     return mcp, config, system
 
 
+def _clear_agent_credential_values_on_unassign(agent: Agent, project: Project) -> None:
+    """Clear stored secret values for credentials linked to the agent, keeping schema rows."""
+    for cred in AgentCredential.objects.filter(agents=agent, project=project):
+        other_agents_still_assigned = IntegratedAgent.objects.filter(
+            project=project,
+            agent__in=cred.agents.exclude(pk=agent.pk),
+        ).exists()
+        if other_agents_still_assigned or not cred.value:
+            continue
+        cred.value = ""
+        cred.save(update_fields=["value"])
+
+
 def _apply_unique_mcp_metadata_to_integrated_agent(integrated_agent: IntegratedAgent, agent: Agent) -> bool:
     """When the agent has exactly one active MCP, set metadata mcp/system (same keys as v1 official assign)."""
     prefetched = getattr(agent, "_prefetched_objects_cache", {}).get("mcps")
@@ -100,11 +113,7 @@ class AssignAgentsUsecase:
                 integrated_agent = IntegratedAgent.objects.get(agent=agent, project=project)
                 deleted_agent = integrated_agent
                 integrated_agent.delete()
-
-                for cred in AgentCredential.objects.filter(agents=agent, project=project):
-                    cred.agents.remove(agent)
-                    if len(cred.agents.all()) == 0:
-                        cred.delete()
+                _clear_agent_credential_values_on_unassign(agent, project)
 
                 return True, deleted_agent
             except IntegratedAgent.DoesNotExist:


### PR DESCRIPTION
- Added unit tests to verify inclusion of agent credentials in MCPs when no linked MCP exists.
- Merged agent credentials into MCPs when templates are empty.
- Updated agent prefetching to include agent credentials for improved data retrieval.
- Introduced new serialization functions for agent credentials to maintain consistent API responses.