### PR TITLE
feat: add internal communication permission checks and related t…

### DIFF
--- a/nexus/agents/api/test_agents_api.py
+++ b/nexus/agents/api/test_agents_api.py
@@ -525,6 +525,33 @@ class TeamViewsetSetTestCase(TestCase):
         self.assertEqual(row["mcps"][0]["name"], "Team Config MCP")
         self.assertEqual(row["mcps"][0]["config"], {"Country": "BRA"})
 
+    @mock.patch("nexus.projects.api.permissions.has_external_general_project_permission", return_value=False)
+    def test_get_team_internal_communication_permission_grants_access(self, _mock_has_project_perm):
+        internal_user = UserFactory()
+        content_type = ContentType.objects.get_for_model(internal_user)
+        permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+        internal_user.user_permissions.add(permission)
+        internal_user = type(internal_user).objects.get(pk=internal_user.pk)
+
+        client = APIClient()
+        client.force_authenticate(user=internal_user)
+        url = reverse("teams", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch("nexus.projects.api.permissions.has_external_general_project_permission", return_value=False)
+    def test_get_team_unauthorized_user_returns_403(self, _mock_has_project_perm):
+        unauthorized_user = UserFactory()
+        client = APIClient()
+        client.force_authenticate(user=unauthorized_user)
+        url = reverse("teams", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        self.assertEqual(response.status_code, 403)
+
 
 class ActivateAgentViewTestCase(TestCase):
     def setUp(self):

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -795,8 +795,14 @@ class AgentProjectsView(APIView):
         )
 
 
+class InternalCommunicationPermission(BasePermission):
+    def has_permission(self, request, view):
+        user = request.user
+        return user.has_perm("users.can_communicate_internally")
+
+
 class TeamView(APIView):
-    permission_classes = [IsAuthenticated, ProjectPermission]
+    permission_classes = [IsAuthenticated, ProjectPermission | InternalCommunicationPermission]
 
     def get(self, request, *args, **kwargs):
         project_uuid = kwargs.get("project_uuid")
@@ -885,12 +891,6 @@ class ProjectCredentialsView(APIView):
             )
 
         return Response({"message": "Credentials created successfully", "created_credentials": created_credentials})
-
-
-class InternalCommunicationPermission(BasePermission):
-    def has_permission(self, request, view):
-        user = request.user
-        return user.has_perm("users.can_communicate_internally")
 
 
 class ActivateAgentView(APIView):


### PR DESCRIPTION
…ests

- Implemented InternalCommunicationPermission to allow users with the "can_communicate_internally" permission to access team data.
- Updated TeamView to include the new permission class in its permission checks.
- Added unit tests to verify access for internal users and ensure unauthorized users receive a 403 response.