### PR TITLE
feat: add last_updated field to my agents endpoint

### DIFF
--- a/nexus/agents/api/test_agents_api.py
+++ b/nexus/agents/api/test_agents_api.py
@@ -1,11 +1,14 @@
 import json
+from datetime import timedelta
 from unittest import mock
 from urllib.parse import urlencode
 
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Max
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APIClient, APIRequestFactory
 
 from nexus.agents.api.views import InternalCommunicationPermission
@@ -67,6 +70,31 @@ class AgentViewsetSetTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(content), 2)
+        for row in content:
+            self.assertIn("last_updated", row)
+            self.assertIsNone(row["last_updated"])
+
+    def test_get_my_agents_last_updated_from_latest_cli_version(self):
+        from nexus.inline_agents.api.serializers.catalog import format_agent_last_updated
+
+        older = timezone.now() - timedelta(days=2)
+        newer = timezone.now() - timedelta(hours=1)
+        v1 = Version.objects.create(skills=[], display_skills=[], agent=self.agent)
+        v2 = Version.objects.create(skills=[], display_skills=[], agent=self.agent)
+        Version.objects.filter(pk=v1.pk).update(created_on=older)
+        Version.objects.filter(pk=v2.pk).update(created_on=newer)
+        expected = format_agent_last_updated(
+            Version.objects.filter(agent=self.agent).aggregate(last=Max("created_on"))["last"]
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("my-agents", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        response.render()
+        content = json.loads(response.content)
+        row = next(r for r in content if r["uuid"] == str(self.agent.uuid))
+        self.assertEqual(row["last_updated"], expected)
 
     def test_get_my_agents_with_search(self):
         query_params = {"search": "information"}
@@ -1357,6 +1385,12 @@ class CatalogRowKeyParityTestCase(TestCase):
         self.assertEqual(frozenset(row.keys()), self.expected_keys)
         self.assertNotIn("agents", row)
 
+    def _assert_my_agents_row_keys(self, row: dict) -> None:
+        from nexus.inline_agents.api.serializers.catalog import MY_AGENTS_LAST_UPDATED_KEY
+
+        self.assertEqual(frozenset(row.keys()), self.expected_keys | {MY_AGENTS_LAST_UPDATED_KEY})
+        self.assertNotIn("agents", row)
+
     def test_my_agents_and_team_share_row_keys(self):
         client = APIClient()
         client.force_authenticate(user=self.user)
@@ -1370,8 +1404,8 @@ class CatalogRowKeyParityTestCase(TestCase):
         team_resp.render()
         team_row = next(r for r in json.loads(team_resp.content)["agents"] if r["uuid"] == str(self.agent.uuid))
 
-        for row in (my_row, team_row):
-            self._assert_catalog_row_keys(row)
+        self._assert_my_agents_row_keys(my_row)
+        self._assert_catalog_row_keys(team_row)
 
     @mock.patch("nexus.projects.api.permissions.has_external_general_project_permission")
     def test_v1_official_group_row_matches_custom_agent_row_keys(self, mock_has_permission):
@@ -1398,7 +1432,8 @@ class CatalogRowKeyParityTestCase(TestCase):
         group_row = next(r for r in _official_v1_grouped_rows(resp.json()) if r["group"] == self.group.slug)
         self._assert_catalog_row_keys(group_row)
         self.assertEqual(group_row["name"], "Parity Display")
-        self.assertEqual(frozenset(group_row.keys()), frozenset(my_row.keys()))
+        self._assert_my_agents_row_keys(my_row)
+        self.assertNotIn("last_updated", group_row)
 
 
 class OfficialAvailableSystemsV1TestCase(TestCase):

--- a/nexus/agents/api/test_agents_api.py
+++ b/nexus/agents/api/test_agents_api.py
@@ -71,30 +71,7 @@ class AgentViewsetSetTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(content), 2)
         for row in content:
-            self.assertIn("last_updated", row)
-            self.assertIsNone(row["last_updated"])
-
-    def test_get_my_agents_last_updated_from_latest_cli_version(self):
-        from nexus.inline_agents.api.serializers.catalog import format_agent_last_updated
-
-        older = timezone.now() - timedelta(days=2)
-        newer = timezone.now() - timedelta(hours=1)
-        v1 = Version.objects.create(skills=[], display_skills=[], agent=self.agent)
-        v2 = Version.objects.create(skills=[], display_skills=[], agent=self.agent)
-        Version.objects.filter(pk=v1.pk).update(created_on=older)
-        Version.objects.filter(pk=v2.pk).update(created_on=newer)
-        expected = format_agent_last_updated(
-            Version.objects.filter(agent=self.agent).aggregate(last=Max("created_on"))["last"]
-        )
-
-        client = APIClient()
-        client.force_authenticate(user=self.user)
-        url = reverse("my-agents", kwargs={"project_uuid": str(self.project.uuid)})
-        response = client.get(url)
-        response.render()
-        content = json.loads(response.content)
-        row = next(r for r in content if r["uuid"] == str(self.agent.uuid))
-        self.assertEqual(row["last_updated"], expected)
+            self.assertNotIn("last_updated", row)
 
     def test_get_my_agents_with_search(self):
         query_params = {"search": "information"}
@@ -368,6 +345,36 @@ class TeamViewsetSetTestCase(TestCase):
             {"en": "Test Agent Description", "pt": None, "es": None},
         )
         self.assertIsNone(row.get("group"))
+
+    def test_get_team_last_updated_from_latest_cli_version(self):
+        from nexus.inline_agents.api.serializers.catalog import format_agent_last_updated
+
+        agent = InlineAgent.objects.create(
+            name="Versioned Agent",
+            slug="versioned_agent",
+            instruction="Test",
+            collaboration_instructions="Test",
+            foundation_model="model:version",
+            project=self.project,
+        )
+        IntegratedAgent.objects.create(agent=agent, project=self.project)
+        older = timezone.now() - timedelta(days=2)
+        newer = timezone.now() - timedelta(hours=1)
+        v1 = Version.objects.create(skills=[], display_skills=[], agent=agent)
+        v2 = Version.objects.create(skills=[], display_skills=[], agent=agent)
+        Version.objects.filter(pk=v1.pk).update(created_on=older)
+        Version.objects.filter(pk=v2.pk).update(created_on=newer)
+        expected = format_agent_last_updated(
+            Version.objects.filter(agent=agent).aggregate(last=Max("created_on"))["last"]
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("teams", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        response.render()
+        row = next(r for r in json.loads(response.content)["agents"] if r["uuid"] == str(agent.uuid))
+        self.assertEqual(row["last_updated"], expected)
 
     def test_get_team_excludes_inactive_integrated_agents(self):
         """Agents with is_active=False on IntegratedAgent do not appear in team list."""
@@ -1384,14 +1391,9 @@ class CatalogRowKeyParityTestCase(TestCase):
     def _assert_catalog_row_keys(self, row: dict) -> None:
         self.assertEqual(frozenset(row.keys()), self.expected_keys)
         self.assertNotIn("agents", row)
+        self.assertNotIn("last_updated", row)
 
-    def _assert_my_agents_row_keys(self, row: dict) -> None:
-        from nexus.inline_agents.api.serializers.catalog import MY_AGENTS_LAST_UPDATED_KEY
-
-        self.assertEqual(frozenset(row.keys()), self.expected_keys | {MY_AGENTS_LAST_UPDATED_KEY})
-        self.assertNotIn("agents", row)
-
-    def test_my_agents_and_team_share_row_keys(self):
+    def test_my_agents_uses_catalog_row_keys(self):
         client = APIClient()
         client.force_authenticate(user=self.user)
         project_uuid = str(self.project.uuid)
@@ -1399,21 +1401,22 @@ class CatalogRowKeyParityTestCase(TestCase):
         my_resp = client.get(reverse("my-agents", kwargs={"project_uuid": project_uuid}))
         my_resp.render()
         my_row = next(r for r in json.loads(my_resp.content) if r["uuid"] == str(self.agent.uuid))
+        self._assert_catalog_row_keys(my_row)
+
+    def test_team_roster_includes_last_updated(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        project_uuid = str(self.project.uuid)
 
         team_resp = client.get(reverse("teams", kwargs={"project_uuid": project_uuid}))
         team_resp.render()
         team_row = next(r for r in json.loads(team_resp.content)["agents"] if r["uuid"] == str(self.agent.uuid))
-
-        self._assert_my_agents_row_keys(my_row)
-        self._assert_catalog_row_keys(team_row)
+        self.assertIn("last_updated", team_row)
+        self.assertIsNotNone(team_row["last_updated"])
 
     @mock.patch("nexus.projects.api.permissions.has_external_general_project_permission")
     def test_v1_official_group_row_matches_custom_agent_row_keys(self, mock_has_permission):
         mock_has_permission.return_value = True
-        owner = ProjectFactory()
-        self.agent.project = owner
-        self.agent.save(update_fields=["project"])
-
         client = APIClient()
         client.force_authenticate(user=self.user)
         project_uuid = str(self.project.uuid)
@@ -1432,7 +1435,7 @@ class CatalogRowKeyParityTestCase(TestCase):
         group_row = next(r for r in _official_v1_grouped_rows(resp.json()) if r["group"] == self.group.slug)
         self._assert_catalog_row_keys(group_row)
         self.assertEqual(group_row["name"], "Parity Display")
-        self._assert_my_agents_row_keys(my_row)
+        self._assert_catalog_row_keys(my_row)
         self.assertNotIn("last_updated", group_row)
 
 

--- a/nexus/inline_agents/api/serializers/__init__.py
+++ b/nexus/inline_agents/api/serializers/__init__.py
@@ -347,7 +347,7 @@ class TeamRosterAgentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = IntegratedAgent
-        fields = ["uuid", "slug", "name", "about", "group", "is_official", "mcps", "active"]
+        fields = ["uuid", "slug", "name", "about", "group", "is_official", "mcps", "active", "last_updated"]
 
     active = serializers.BooleanField(source="is_active", read_only=True)
     uuid = serializers.UUIDField(source="agent.uuid")
@@ -357,6 +357,7 @@ class TeamRosterAgentSerializer(serializers.ModelSerializer):
     group = serializers.SerializerMethodField()
     is_official = serializers.SerializerMethodField()
     mcps = serializers.SerializerMethodField()
+    last_updated = serializers.SerializerMethodField()
 
     def get_slug(self, obj):
         return obj.agent.slug
@@ -377,6 +378,11 @@ class TeamRosterAgentSerializer(serializers.ModelSerializer):
 
     def get_mcps(self, obj):
         return team_roster_mcps_payload(obj)
+
+    def get_last_updated(self, obj):
+        from nexus.inline_agents.api.serializers.catalog import format_agent_last_updated
+
+        return format_agent_last_updated(getattr(obj, "last_version_at", None))
 
 
 class AgentSerializer(serializers.ModelSerializer):

--- a/nexus/inline_agents/api/serializers/catalog.py
+++ b/nexus/inline_agents/api/serializers/catalog.py
@@ -59,22 +59,12 @@ CATALOG_ROW_KEYS: frozenset[str] = frozenset(
 # Backward-compatible alias for tests/imports.
 CATALOG_AGENT_ROW_KEYS = CATALOG_ROW_KEYS
 
-# Present only on ``GET agents/my-agents`` (CLI push history via ``Version.created_on``).
-MY_AGENTS_LAST_UPDATED_KEY = "last_updated"
-
 
 def format_agent_last_updated(value: datetime | None) -> str | None:
     """ISO-8601 timestamp for the latest CLI push version, or ``None`` when never pushed."""
     if value is None:
         return None
     return pendulum.instance(value).in_timezone("UTC").to_iso8601_string()
-
-
-def enrich_my_agents_row(row: dict[str, Any], agent: Agent) -> dict[str, Any]:
-    """Add ``last_updated`` from queryset annotation ``last_version_at`` (``Max(versions__created_on)``)."""
-    last_version_at = getattr(agent, "last_version_at", None)
-    row[MY_AGENTS_LAST_UPDATED_KEY] = format_agent_last_updated(last_version_at)
-    return row
 
 
 def project_agent_assignment_map(

--- a/nexus/inline_agents/api/serializers/catalog.py
+++ b/nexus/inline_agents/api/serializers/catalog.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime
 from itertools import groupby
 from typing import Any
 
+import pendulum
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Prefetch
 
@@ -56,6 +58,23 @@ CATALOG_ROW_KEYS: frozenset[str] = frozenset(
 
 # Backward-compatible alias for tests/imports.
 CATALOG_AGENT_ROW_KEYS = CATALOG_ROW_KEYS
+
+# Present only on ``GET agents/my-agents`` (CLI push history via ``Version.created_on``).
+MY_AGENTS_LAST_UPDATED_KEY = "last_updated"
+
+
+def format_agent_last_updated(value: datetime | None) -> str | None:
+    """ISO-8601 timestamp for the latest CLI push version, or ``None`` when never pushed."""
+    if value is None:
+        return None
+    return pendulum.instance(value).in_timezone("UTC").to_iso8601_string()
+
+
+def enrich_my_agents_row(row: dict[str, Any], agent: Agent) -> dict[str, Any]:
+    """Add ``last_updated`` from queryset annotation ``last_version_at`` (``Max(versions__created_on)``)."""
+    last_version_at = getattr(agent, "last_version_at", None)
+    row[MY_AGENTS_LAST_UPDATED_KEY] = format_agent_last_updated(last_version_at)
+    return row
 
 
 def project_agent_assignment_map(

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -3,7 +3,7 @@ import logging
 
 import pendulum
 from django.conf import settings
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Count, Max, Prefetch, Q
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, OpenApiTypes, extend_schema
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
@@ -28,6 +28,7 @@ from nexus.inline_agents.api.serializers import (
 )
 from nexus.inline_agents.api.serializers.catalog import (
     build_row_from_project_agent,
+    enrich_my_agents_row,
     my_agents_list_prefetches,
     project_agent_assignment_map,
 )
@@ -684,7 +685,11 @@ class AgentsView(APIView):
         project_uuid = kwargs.get("project_uuid")
         search = self.request.query_params.get("search")
 
-        agents = Agent.objects.filter(project__uuid=project_uuid).select_related("group", "group__modal")
+        agents = (
+            Agent.objects.filter(project__uuid=project_uuid)
+            .select_related("group", "group__modal")
+            .annotate(last_version_at=Max("versions__created_on"))
+        )
 
         if search:
             query_filter = (
@@ -699,11 +704,14 @@ class AgentsView(APIView):
             project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
         )
         data = [
-            build_row_from_project_agent(
+            enrich_my_agents_row(
+                build_row_from_project_agent(
+                    agent,
+                    project_uuid,
+                    include_inactive_integrated=False,
+                    assignment_by_agent_id=assignment,
+                ),
                 agent,
-                project_uuid,
-                include_inactive_integrated=False,
-                assignment_by_agent_id=assignment,
             )
             for agent in agents
         ]

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -28,7 +28,6 @@ from nexus.inline_agents.api.serializers import (
 )
 from nexus.inline_agents.api.serializers.catalog import (
     build_row_from_project_agent,
-    enrich_my_agents_row,
     my_agents_list_prefetches,
     project_agent_assignment_map,
 )
@@ -685,11 +684,7 @@ class AgentsView(APIView):
         project_uuid = kwargs.get("project_uuid")
         search = self.request.query_params.get("search")
 
-        agents = (
-            Agent.objects.filter(project__uuid=project_uuid)
-            .select_related("group", "group__modal")
-            .annotate(last_version_at=Max("versions__created_on"))
-        )
+        agents = Agent.objects.filter(project__uuid=project_uuid).select_related("group", "group__modal")
 
         if search:
             query_filter = (
@@ -704,14 +699,11 @@ class AgentsView(APIView):
             project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
         )
         data = [
-            enrich_my_agents_row(
-                build_row_from_project_agent(
-                    agent,
-                    project_uuid,
-                    include_inactive_integrated=False,
-                    assignment_by_agent_id=assignment,
-                ),
+            build_row_from_project_agent(
                 agent,
+                project_uuid,
+                include_inactive_integrated=False,
+                assignment_by_agent_id=assignment,
             )
             for agent in agents
         ]
@@ -809,12 +801,16 @@ class TeamView(APIView):
     def get(self, request, *args, **kwargs):
         project_uuid = kwargs.get("project_uuid")
         usecase = GetInlineAgentsUsecase()
-        agents = usecase.get_active_agents(project_uuid).prefetch_related(
-            "agent__group",
-            "agent__group__modal",
-            "agent__mcps",
-            "agent__mcps__system",
-            "agent__mcps__config_options",
+        agents = (
+            usecase.get_active_agents(project_uuid)
+            .annotate(last_version_at=Max("agent__versions__created_on"))
+            .prefetch_related(
+                "agent__group",
+                "agent__group__modal",
+                "agent__mcps",
+                "agent__mcps__system",
+                "agent__mcps__config_options",
+            )
         )
         serializer = TeamRosterAgentSerializer(agents, many=True)
 


### PR DESCRIPTION
Enhanced the my agents API to include a last_updated field, reflecting the latest CLI push version timestamp. Updated the AgentsView to annotate agents with the maximum created_on date from their versions. Introduced a new serializer function to format this timestamp and updated related tests to validate the new functionality.