### PR TITLE
feat: implement message conversation log handling in OpenAI backend

### DIFF
--- a/inline_agents/backends/openai/backend.py
+++ b/inline_agents/backends/openai/backend.py
@@ -319,6 +319,7 @@ class OpenAIBackend(InlineAgentsBackend):
 
         message_conversation_log_uuid = kwargs.pop("message_conversation_log_uuid", None)
         skip_conversation_sqs = kwargs.pop("skip_conversation_sqs", False)
+        hooks_state.message_conversation_log_uuid = message_conversation_log_uuid
 
         save_inline_message_async.delay(
             project_uuid=project_uuid,

--- a/inline_agents/backends/openai/entities.py
+++ b/inline_agents/backends/openai/entities.py
@@ -22,6 +22,7 @@ class HooksState:
         # Accumulated usage for the whole run (manager + collaborators) when updating manager span
         self.cumulative_usage = {"input": 0, "output": 0, "cache_read_input_tokens": 0}
         self.skip_outgoing_dispatch: bool = False
+        self.message_conversation_log_uuid: str | None = None
 
         for agent in self.agents:
             self.agents_names.append(agent.get("agentName"))

--- a/inline_agents/backends/openai/hooks.py
+++ b/inline_agents/backends/openai/hooks.py
@@ -21,6 +21,12 @@ from opentelemetry import trace
 
 from inline_agents.adapter import DataLakeEventAdapter
 from inline_agents.backends.openai.entities import FinalResponse, HooksState
+from router.tasks.sqs_message_events import (
+    extract_messages_sent_texts,
+    parse_tool_result,
+    send_tool_messages_sent_to_conversation_sqs,
+    tool_result_has_final_output,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +217,37 @@ def _result_to_value(result):
         except (json.JSONDecodeError, TypeError):
             return result
     return result
+
+
+def _maybe_send_tool_messages_sent_to_conversation(
+    context_data,
+    result,
+    *,
+    preview: bool,
+    skip_conversation_sqs: bool,
+    hooks_state: HooksState,
+    tool_name: str = "",
+) -> None:
+    """Send messages_sent texts to conversation SQS when tool is not a final-output payload."""
+    if preview or skip_conversation_sqs:
+        return
+    parsed = parse_tool_result(result)
+    if not isinstance(parsed, dict):
+        return
+    if tool_result_has_final_output(parsed):
+        return
+    texts = extract_messages_sent_texts(parsed)
+    if not texts:
+        return
+    send_tool_messages_sent_to_conversation_sqs(
+        texts=texts,
+        project_uuid=context_data.project.get("uuid"),
+        contact_urn=context_data.contact.get("urn"),
+        channel_uuid=context_data.contact.get("channel_uuid"),
+        contact_name=context_data.contact.get("name") or "",
+        message_conversation_log_uuid=hooks_state.message_conversation_log_uuid,
+        tool_name=tool_name,
+    )
 
 
 class TraceHandler:
@@ -656,6 +693,15 @@ class CollaboratorHooks(AgentHooks):  # type: ignore[misc]
 
         logger.info(f"[HOOK] Resultado da ferramenta '{tool.name}' recebido {result}.")
 
+        _maybe_send_tool_messages_sent_to_conversation(
+            context_data,
+            result,
+            preview=self.preview,
+            skip_conversation_sqs=self.skip_conversation_sqs,
+            hooks_state=self.hooks_state,
+            tool_name=tool.name,
+        )
+
         contact_urn = context_data.contact.get("urn", "unknown")
         events = _get_events_from_tool_result(result, tool.name, self.hooks_state, project_uuid, contact_urn)
         events_list = _normalize_events_to_list(events, tool.name, project_uuid)
@@ -918,6 +964,14 @@ class SupervisorHooks(AgentHooks):  # type: ignore[misc]
 
     async def _on_tool_end_regular_tool(self, context, agent, tool, result, context_data, project_uuid, parameters):
         """Handle on_tool_end for regular (non-agent) tools."""
+        _maybe_send_tool_messages_sent_to_conversation(
+            context_data,
+            result,
+            preview=self.preview,
+            skip_conversation_sqs=self.skip_conversation_sqs,
+            hooks_state=self.hooks_state,
+            tool_name=tool.name,
+        )
         contact_urn = context_data.contact.get("urn", "unknown")
         events = _get_events_from_tool_result(result, tool.name, self.hooks_state, project_uuid, contact_urn)
         events_list = _normalize_events_to_list(events, tool.name, project_uuid)

--- a/inline_agents/backends/openai/tests/test_tool_messages_sent_hooks.py
+++ b/inline_agents/backends/openai/tests/test_tool_messages_sent_hooks.py
@@ -1,0 +1,72 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from inline_agents.backends.openai.entities import HooksState
+from inline_agents.backends.openai.hooks import _maybe_send_tool_messages_sent_to_conversation
+
+
+class MaybeSendToolMessagesSentTests(SimpleTestCase):
+    def _context_data(self):
+        context_data = MagicMock()
+        context_data.project.get.return_value = "proj-1"
+        context_data.contact.get.side_effect = lambda key, default="": {
+            "urn": "urn:1",
+            "channel_uuid": "chan-1",
+            "name": "Alice",
+        }.get(key, default)
+        return context_data
+
+    def _hooks_state(self):
+        hooks_state = HooksState(agents=[])
+        hooks_state.message_conversation_log_uuid = "log-uuid"
+        return hooks_state
+
+    @patch("inline_agents.backends.openai.hooks.send_tool_messages_sent_to_conversation_sqs")
+    def test_sends_when_messages_sent_without_is_final_output(self, mock_send):
+        result = {
+            "result": {"message": "compose me", "broadcasts_sent": 2},
+            "messages_sent": [{"text": "first"}, {"text": "second"}],
+        }
+        _maybe_send_tool_messages_sent_to_conversation(
+            self._context_data(),
+            json.dumps(result),
+            preview=False,
+            skip_conversation_sqs=False,
+            hooks_state=self._hooks_state(),
+            tool_name="sendmessages",
+        )
+        mock_send.assert_called_once_with(
+            texts=["first", "second"],
+            project_uuid="proj-1",
+            contact_urn="urn:1",
+            channel_uuid="chan-1",
+            contact_name="Alice",
+            message_conversation_log_uuid="log-uuid",
+            tool_name="sendmessages",
+        )
+
+    @patch("inline_agents.backends.openai.hooks.send_tool_messages_sent_to_conversation_sqs")
+    def test_skips_when_is_final_output(self, mock_send):
+        result = {"is_final_output": True, "messages_sent": [{"text": "a"}]}
+        _maybe_send_tool_messages_sent_to_conversation(
+            self._context_data(),
+            result,
+            preview=False,
+            skip_conversation_sqs=False,
+            hooks_state=self._hooks_state(),
+        )
+        mock_send.assert_not_called()
+
+    @patch("inline_agents.backends.openai.hooks.send_tool_messages_sent_to_conversation_sqs")
+    def test_skips_in_preview(self, mock_send):
+        result = {"messages_sent": [{"text": "a"}]}
+        _maybe_send_tool_messages_sent_to_conversation(
+            self._context_data(),
+            result,
+            preview=True,
+            skip_conversation_sqs=False,
+            hooks_state=self._hooks_state(),
+        )
+        mock_send.assert_not_called()

--- a/router/tasks/sqs_message_events.py
+++ b/router/tasks/sqs_message_events.py
@@ -6,18 +6,91 @@ channel_uuid, message with id, text, source, created_at, contact_name).
 All fields are required.
 """
 
+import ast
 import json
+import logging
 import uuid
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
+
+import pendulum
+import sentry_sdk
+
+from router.services.sqs_producer import get_conversation_events_producer
+
+logger = logging.getLogger(__name__)
 
 EVENT_TYPE_MESSAGE_RECEIVED = "message.received"
 EVENT_TYPE_MESSAGE_SENT = "message.sent"
 
 
-def sqs_response_text_from_agent_output(  # noqa: C901
-    response: str, *, skip_dispatch: bool
-) -> str:
+def parse_tool_result(raw: Any) -> Any:
+    """Parse tool result (str/dict/list) into a Python value."""
+    if isinstance(raw, (dict, list)):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                pass
+    return raw
+
+
+def _messages_sent_list_from_dict(parsed: dict) -> list:
+    """Extract messages_sent list from flat or Lambda-style payloads."""
+    messages_sent: list = []
+    top_msgs = parsed.get("messages_sent")
+    if isinstance(top_msgs, list):
+        messages_sent = top_msgs
+    inner = parsed.get("result")
+    if isinstance(inner, dict):
+        if not messages_sent:
+            inner_msgs = inner.get("messages_sent")
+            if isinstance(inner_msgs, list):
+                messages_sent = inner_msgs
+    return messages_sent
+
+
+def tool_result_has_final_output(parsed: dict) -> bool:
+    """True when is_final_output is set at top level or under result."""
+    is_final = bool(parsed.get("is_final_output"))
+    inner = parsed.get("result")
+    if isinstance(inner, dict) and not is_final:
+        is_final = bool(inner.get("is_final_output"))
+    return is_final
+
+
+def extract_messages_sent_texts(parsed: Any) -> list[str]:
+    """Return non-empty text values from messages_sent in a tool result dict."""
+    if not isinstance(parsed, dict):
+        return []
+    messages_sent = _messages_sent_list_from_dict(parsed)
+    text_lines: list[str] = []
+    for sent_item in messages_sent:
+        if isinstance(sent_item, dict):
+            line = str(sent_item.get("text", "")).strip()
+            if line:
+                text_lines.append(line)
+    return text_lines
+
+
+def _text_lines_from_merge_style_list(parsed: list) -> list[str]:
+    text_lines: list[str] = []
+    for channel_msg in parsed:
+        if not isinstance(channel_msg, dict):
+            continue
+        msg_payload = channel_msg.get("msg")
+        if isinstance(msg_payload, dict):
+            line = str(msg_payload.get("text", "")).strip()
+            if line:
+                text_lines.append(line)
+    return text_lines
+
+
+def sqs_response_text_from_agent_output(response: str, *, skip_dispatch: bool) -> str:
     """
     Text used in message.sent (via notify_async → observers) for SQS.
 
@@ -28,37 +101,60 @@ def sqs_response_text_from_agent_output(  # noqa: C901
     """
     if not skip_dispatch or not (response or "").strip():
         return response
-    try:
-        parsed = json.loads(response)
-    except (json.JSONDecodeError, TypeError):
-        return response
+    parsed = parse_tool_result(response)
     if isinstance(parsed, list):
-        text_lines: list[str] = []
-        for channel_msg in parsed:
-            if not isinstance(channel_msg, dict):
-                continue
-            msg_payload = channel_msg.get("msg")
-            if isinstance(msg_payload, dict):
-                line = str(msg_payload.get("text", "")).strip()
-                if line:
-                    text_lines.append(line)
+        text_lines = _text_lines_from_merge_style_list(parsed)
         if text_lines:
             return "\n".join(text_lines)
         return response
     if not isinstance(parsed, dict):
         return response
-    messages_sent = parsed.get("messages_sent")
-    if not isinstance(messages_sent, list):
-        return response
-    text_lines: list[str] = []
-    for sent_item in messages_sent:
-        if isinstance(sent_item, dict):
-            line = str(sent_item.get("text", "")).strip()
-            if line:
-                text_lines.append(line)
+    text_lines = extract_messages_sent_texts(parsed)
     if not text_lines:
         return response
     return "\n".join(text_lines)
+
+
+def send_tool_messages_sent_to_conversation_sqs(
+    *,
+    texts: list[str],
+    project_uuid: str,
+    contact_urn: str,
+    channel_uuid: str,
+    contact_name: str,
+    message_conversation_log_uuid: Optional[str] = None,
+    tool_name: str = "",
+) -> None:
+    """Send one message.sent SQS event per text from a tool messages_sent payload."""
+    if not texts:
+        return
+    created_at = pendulum.now().to_iso8601_string()
+    base_id = message_conversation_log_uuid or str(uuid.uuid4())
+    for index, text in enumerate(texts):
+        message_id = f"{base_id}:tool:{index}"
+        correlation_id = f"{base_id}:tool:{index}"
+        sent_event = build_message_sent_event(
+            project_uuid=project_uuid,
+            contact_urn=contact_urn,
+            channel_uuid=channel_uuid,
+            contact_name=contact_name,
+            message_text=text,
+            created_at=created_at,
+            message_id=message_id,
+            correlation_id=correlation_id,
+        )
+        try:
+            get_conversation_events_producer().send_event(sent_event.to_dict())
+        except Exception as exc:
+            logger.exception(
+                "Failed to send tool messages_sent event to SQS",
+                extra={
+                    "project_uuid": project_uuid,
+                    "tool_name": tool_name,
+                    "message_index": index,
+                },
+            )
+            sentry_sdk.capture_exception(exc)
 
 
 @dataclass(frozen=True)

--- a/router/tasks/tests/test_sqs_message_events.py
+++ b/router/tasks/tests/test_sqs_message_events.py
@@ -1,7 +1,14 @@
 import json
 import unittest
+from unittest.mock import MagicMock, patch
 
-from router.tasks.sqs_message_events import sqs_response_text_from_agent_output
+from router.tasks.sqs_message_events import (
+    EVENT_TYPE_MESSAGE_SENT,
+    extract_messages_sent_texts,
+    send_tool_messages_sent_to_conversation_sqs,
+    sqs_response_text_from_agent_output,
+    tool_result_has_final_output,
+)
 
 
 class TestSqsResponseTextFromAgentOutput(unittest.TestCase):
@@ -62,3 +69,89 @@ class TestSqsResponseTextFromAgentOutput(unittest.TestCase):
             sqs_response_text_from_agent_output(raw, skip_dispatch=True),
             "a",
         )
+
+
+class TestExtractMessagesSentTexts(unittest.TestCase):
+    def test_sendmessages_style_payload_without_is_final_output(self):
+        parsed = {
+            "result": {"message": "Terceira mensagem", "broadcasts_sent": 2},
+            "messages_sent": [
+                {"text": "Primeira mensagem genérica enviada via broadcast."},
+                {"text": "Segunda mensagem genérica enviada via broadcast."},
+            ],
+        }
+        self.assertEqual(
+            extract_messages_sent_texts(parsed),
+            [
+                "Primeira mensagem genérica enviada via broadcast.",
+                "Segunda mensagem genérica enviada via broadcast.",
+            ],
+        )
+        self.assertFalse(tool_result_has_final_output(parsed))
+
+    def test_nested_messages_sent_under_result(self):
+        parsed = {
+            "result": {
+                "is_final_output": False,
+                "messages_sent": [{"text": "inner only"}],
+            },
+        }
+        self.assertEqual(extract_messages_sent_texts(parsed), ["inner only"])
+
+    def test_top_level_messages_sent_preferred_over_empty(self):
+        parsed = {
+            "result": {"messages_sent": [{"text": "inner"}]},
+            "messages_sent": [{"text": "top"}],
+        }
+        self.assertEqual(extract_messages_sent_texts(parsed), ["top"])
+
+
+class TestToolResultHasFinalOutput(unittest.TestCase):
+    def test_top_level_flag(self):
+        self.assertTrue(tool_result_has_final_output({"is_final_output": True}))
+
+    def test_nested_flag(self):
+        self.assertTrue(
+            tool_result_has_final_output({"result": {"is_final_output": True}, "messages_sent": []})
+        )
+
+    def test_no_flag(self):
+        self.assertFalse(tool_result_has_final_output({"messages_sent": [{"text": "a"}]}))
+
+
+class TestSendToolMessagesSentToConversationSqs(unittest.TestCase):
+    @patch("router.tasks.sqs_message_events.get_conversation_events_producer")
+    def test_sends_one_event_per_text(self, mock_get_producer):
+        producer = MagicMock()
+        mock_get_producer.return_value = producer
+
+        send_tool_messages_sent_to_conversation_sqs(
+            texts=["first", "second"],
+            project_uuid="proj-1",
+            contact_urn="urn:1",
+            channel_uuid="chan-1",
+            contact_name="Alice",
+            message_conversation_log_uuid="log-uuid",
+            tool_name="sendmessages",
+        )
+
+        self.assertEqual(producer.send_event.call_count, 2)
+        first_event = producer.send_event.call_args_list[0][0][0]
+        second_event = producer.send_event.call_args_list[1][0][0]
+        self.assertEqual(first_event["event_type"], EVENT_TYPE_MESSAGE_SENT)
+        self.assertEqual(first_event["data"]["message"]["text"], "first")
+        self.assertEqual(first_event["data"]["message"]["id"], "log-uuid:tool:0")
+        self.assertEqual(first_event["correlation_id"], "log-uuid:tool:0")
+        self.assertEqual(second_event["data"]["message"]["text"], "second")
+        self.assertEqual(second_event["data"]["message"]["id"], "log-uuid:tool:1")
+
+    @patch("router.tasks.sqs_message_events.get_conversation_events_producer")
+    def test_empty_texts_no_send(self, mock_get_producer):
+        send_tool_messages_sent_to_conversation_sqs(
+            texts=[],
+            project_uuid="proj-1",
+            contact_urn="urn:1",
+            channel_uuid="chan-1",
+            contact_name="Alice",
+        )
+        mock_get_producer.assert_not_called()


### PR DESCRIPTION
- Added `message_conversation_log_uuid` to `HooksState` to track conversation logs.
- Enhanced `_maybe_send_tool_messages_sent_to_conversation` function to utilize the new log UUID when sending messages to SQS.
- Updated `OpenAIBackend` to set the conversation log UUID from keyword arguments.
- Introduced unit tests for the new functionality, ensuring proper message handling and SQS event dispatching.