### PR TITLE
feat: add CSV export functionality for project instructions

### DIFF
--- a/nexus/intelligences/api/instruction_views.py
+++ b/nexus/intelligences/api/instruction_views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.http import HttpResponse
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, OpenApiTypes, extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -61,6 +62,34 @@ class ProjectInstructionsViewSet(ModelViewSet):
         content_base = self._get_content_base(project_uuid)
         data = self.use_case.get_grouped_instructions(content_base)
         return Response(data=data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        operation_id="export_project_instructions",
+        summary="Export project instructions as CSV",
+        description="Returns a CSV file with all project instructions as a flat list for download.",
+        parameters=[
+            OpenApiParameter(
+                name="project_uuid",
+                location=OpenApiParameter.PATH,
+                description="Project UUID",
+                required=True,
+                type=OpenApiTypes.STR,
+            )
+        ],
+        responses={
+            200: OpenApiResponse(description="CSV file download"),
+            403: OpenApiResponse(description="Forbidden"),
+        },
+        tags=["Instructions"],
+    )
+    def export(self, request, *args, **kwargs):
+        project_uuid = kwargs.get("project_uuid")
+        content_base = self._get_content_base(project_uuid)
+        csv_content = self.use_case.build_instructions_csv(content_base)
+
+        response = HttpResponse(csv_content, content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = f'attachment; filename="instructions_{project_uuid}.csv"'
+        return response
 
     @extend_schema(
         operation_id="create_project_instruction",

--- a/nexus/intelligences/api/instruction_views.py
+++ b/nexus/intelligences/api/instruction_views.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, OpenApiTypes, extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
@@ -24,6 +25,15 @@ from nexus.usecases.intelligences.instructions import ProjectInstructionsUseCase
 logger = logging.getLogger(__name__)
 
 
+class InstructionsCSVRenderer(BaseRenderer):
+    media_type = "text/csv"
+    format = "csv"
+    charset = "utf-8"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
 class ProjectInstructionsViewSet(ModelViewSet):
     authentication_classes = AUTHENTICATION_CLASSES
     permission_classes = [IsAuthenticated, ProjectPermission, FeatureFlagPermission]
@@ -38,6 +48,11 @@ class ProjectInstructionsViewSet(ModelViewSet):
 
     def _get_content_base(self, project_uuid):
         return get_default_content_base_by_project(project_uuid)
+
+    def get_renderers(self):
+        if getattr(self, "action", None) == "export":
+            return [InstructionsCSVRenderer()]
+        return super().get_renderers()
 
     @extend_schema(
         operation_id="list_project_instructions",
@@ -66,7 +81,10 @@ class ProjectInstructionsViewSet(ModelViewSet):
     @extend_schema(
         operation_id="export_project_instructions",
         summary="Export project instructions as CSV",
-        description="Returns a CSV file with all project instructions as a flat list for download.",
+        description=(
+            "Returns a CSV file with all project instructions for download. "
+            "Each row contains category and instruction columns."
+        ),
         parameters=[
             OpenApiParameter(
                 name="project_uuid",

--- a/nexus/intelligences/api/routers.py
+++ b/nexus/intelligences/api/routers.py
@@ -120,6 +120,11 @@ urlpatterns = [
         name="project-instructions",
     ),
     path(
+        "<project_uuid>/instructions/export/",
+        ProjectInstructionsViewSet.as_view({"get": "export"}),
+        name="project-instructions-export",
+    ),
+    path(
         "<project_uuid>/instructions/categories/<int:category_id>/",
         ProjectInstructionsViewSet.as_view({"delete": "destroy_category"}),
         name="project-instruction-category-delete",

--- a/nexus/intelligences/api/tests/test_instruction_views.py
+++ b/nexus/intelligences/api/tests/test_instruction_views.py
@@ -235,14 +235,26 @@ class TestProjectInstructionsViewSet(TestCase):
         self.assertIn(f"instructions_{self.project.uuid}.csv", response["Content-Disposition"])
 
         rows = list(csv.reader(io.StringIO(response.content.decode("utf-8"))))
-        self.assertEqual(rows[0], ["instruction"])
+        self.assertEqual(rows[0], ["category", "instruction"])
         self.assertEqual(
             rows[1:],
             [
-                ["Always greet the customer"],
-                ["Legacy instruction"],
+                ["greeting", "Always greet the customer"],
+                ["", "Legacy instruction"],
             ],
         )
+
+    def test_export_accepts_text_csv_accept_header(self):
+        export_url = f"{self.project.uuid}/instructions/export/"
+        request = self.factory.get(export_url, HTTP_ACCEPT="text/csv")
+        force_authenticate(request, user=self.user)
+        response = ProjectInstructionsViewSet.as_view({"get": "export"})(
+            request,
+            project_uuid=str(self.project.uuid),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
 
     def test_export_returns_header_only_when_no_instructions(self):
         export_url = f"{self.project.uuid}/instructions/export/"
@@ -255,7 +267,7 @@ class TestProjectInstructionsViewSet(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         rows = list(csv.reader(io.StringIO(response.content.decode("utf-8"))))
-        self.assertEqual(rows, [["instruction"]])
+        self.assertEqual(rows, [["category", "instruction"]])
 
     @mock.patch("nexus.feature_flags.permissions.is_feature_active_for_attributes", return_value=False)
     def test_export_returns_403_when_feature_flag_is_inactive(self, _mock_feature_flag):

--- a/nexus/intelligences/api/tests/test_instruction_views.py
+++ b/nexus/intelligences/api/tests/test_instruction_views.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import json
 from unittest import mock
 
@@ -206,6 +208,66 @@ class TestProjectInstructionsViewSet(TestCase):
         response = self._patch({})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_export_returns_csv_with_all_instructions(self):
+        greeting = InstructionCategory.objects.create(content_base=self.content_base, name="greeting")
+        ContentBaseInstruction.objects.create(
+            content_base=self.content_base,
+            category=greeting,
+            instruction="Always greet the customer",
+        )
+        ContentBaseInstruction.objects.create(
+            content_base=self.content_base,
+            instruction="Legacy instruction",
+        )
+
+        export_url = f"{self.project.uuid}/instructions/export/"
+        request = self.factory.get(export_url)
+        force_authenticate(request, user=self.user)
+        response = ProjectInstructionsViewSet.as_view({"get": "export"})(
+            request,
+            project_uuid=str(self.project.uuid),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertIn(f"instructions_{self.project.uuid}.csv", response["Content-Disposition"])
+
+        rows = list(csv.reader(io.StringIO(response.content.decode("utf-8"))))
+        self.assertEqual(rows[0], ["instruction"])
+        self.assertEqual(
+            rows[1:],
+            [
+                ["Always greet the customer"],
+                ["Legacy instruction"],
+            ],
+        )
+
+    def test_export_returns_header_only_when_no_instructions(self):
+        export_url = f"{self.project.uuid}/instructions/export/"
+        request = self.factory.get(export_url)
+        force_authenticate(request, user=self.user)
+        response = ProjectInstructionsViewSet.as_view({"get": "export"})(
+            request,
+            project_uuid=str(self.project.uuid),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rows = list(csv.reader(io.StringIO(response.content.decode("utf-8"))))
+        self.assertEqual(rows, [["instruction"]])
+
+    @mock.patch("nexus.feature_flags.permissions.is_feature_active_for_attributes", return_value=False)
+    def test_export_returns_403_when_feature_flag_is_inactive(self, _mock_feature_flag):
+        export_url = f"{self.project.uuid}/instructions/export/"
+        request = self.factory.get(export_url)
+        force_authenticate(request, user=self.user)
+        response = ProjectInstructionsViewSet.as_view({"get": "export"})(
+            request,
+            project_uuid=str(self.project.uuid),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @mock.patch("nexus.feature_flags.permissions.is_feature_active_for_attributes", return_value=False)
     def test_list_returns_403_when_feature_flag_is_inactive(self, _mock_feature_flag):

--- a/nexus/usecases/intelligences/instructions.py
+++ b/nexus/usecases/intelligences/instructions.py
@@ -37,15 +37,15 @@ class ProjectInstructionsUseCase:
     def build_instructions_csv(self, content_base: ContentBase) -> str:
         output = io.StringIO()
         writer = csv.writer(output, lineterminator="\n")
-        writer.writerow(["instruction"])
+        writer.writerow(["category", "instruction"])
 
         for category in content_base.instruction_categories.prefetch_related("instructions").order_by("id"):
             for instruction in category.instructions.all().order_by("id"):
-                writer.writerow([instruction.instruction])
+                writer.writerow([category.name, instruction.instruction])
 
         uncategorized = content_base.instructions.filter(category__isnull=True).order_by("id")
         for instruction in uncategorized:
-            writer.writerow([instruction.instruction])
+            writer.writerow(["", instruction.instruction])
 
         return output.getvalue()
 

--- a/nexus/usecases/intelligences/instructions.py
+++ b/nexus/usecases/intelligences/instructions.py
@@ -1,3 +1,5 @@
+import csv
+import io
 from typing import Any
 
 from django.forms.models import model_to_dict
@@ -31,6 +33,21 @@ class ProjectInstructionsUseCase:
             payload["uncategorized_instructions"] = uncategorized_instructions
 
         return payload
+
+    def build_instructions_csv(self, content_base: ContentBase) -> str:
+        output = io.StringIO()
+        writer = csv.writer(output, lineterminator="\n")
+        writer.writerow(["instruction"])
+
+        for category in content_base.instruction_categories.prefetch_related("instructions").order_by("id"):
+            for instruction in category.instructions.all().order_by("id"):
+                writer.writerow([instruction.instruction])
+
+        uncategorized = content_base.instructions.filter(category__isnull=True).order_by("id")
+        for instruction in uncategorized:
+            writer.writerow([instruction.instruction])
+
+        return output.getvalue()
 
     def create_instruction(
         self,

--- a/nexus/usecases/intelligences/tests/test_instructions.py
+++ b/nexus/usecases/intelligences/tests/test_instructions.py
@@ -1,3 +1,6 @@
+import csv
+import io
+
 from django.test import TestCase
 
 from nexus.intelligences.models import ContentBaseInstruction, InstructionCategory
@@ -31,6 +34,37 @@ class TestProjectInstructionsUseCase(TestCase):
         self.assertEqual(len(payload["categories"]), 1)
         self.assertEqual(len(payload["uncategorized_instructions"]), 1)
         self.assertEqual(payload["uncategorized_instructions"][0]["instruction"], "Legacy instruction")
+
+    def test_build_instructions_csv_exports_flat_instruction_list(self):
+        greeting = InstructionCategory.objects.create(content_base=self.content_base, name="greeting")
+        InstructionCategory.objects.create(content_base=self.content_base, name="policy")
+        ContentBaseInstruction.objects.create(
+            content_base=self.content_base,
+            category=greeting,
+            instruction="Always greet the customer",
+        )
+        ContentBaseInstruction.objects.create(
+            content_base=self.content_base,
+            instruction="Legacy instruction",
+        )
+
+        csv_content = self.use_case.build_instructions_csv(self.content_base)
+        rows = list(csv.reader(io.StringIO(csv_content)))
+
+        self.assertEqual(rows[0], ["instruction"])
+        self.assertEqual(
+            rows[1:],
+            [
+                ["Always greet the customer"],
+                ["Legacy instruction"],
+            ],
+        )
+
+    def test_build_instructions_csv_returns_header_only_when_no_instructions(self):
+        csv_content = self.use_case.build_instructions_csv(self.content_base)
+        rows = list(csv.reader(io.StringIO(csv_content)))
+
+        self.assertEqual(rows, [["instruction"]])
 
     def test_create_instruction_uncategorized(self):
         self.use_case.create_instruction(

--- a/nexus/usecases/intelligences/tests/test_instructions.py
+++ b/nexus/usecases/intelligences/tests/test_instructions.py
@@ -51,12 +51,12 @@ class TestProjectInstructionsUseCase(TestCase):
         csv_content = self.use_case.build_instructions_csv(self.content_base)
         rows = list(csv.reader(io.StringIO(csv_content)))
 
-        self.assertEqual(rows[0], ["instruction"])
+        self.assertEqual(rows[0], ["category", "instruction"])
         self.assertEqual(
             rows[1:],
             [
-                ["Always greet the customer"],
-                ["Legacy instruction"],
+                ["greeting", "Always greet the customer"],
+                ["", "Legacy instruction"],
             ],
         )
 
@@ -64,7 +64,7 @@ class TestProjectInstructionsUseCase(TestCase):
         csv_content = self.use_case.build_instructions_csv(self.content_base)
         rows = list(csv.reader(io.StringIO(csv_content)))
 
-        self.assertEqual(rows, [["instruction"]])
+        self.assertEqual(rows, [["category", "instruction"]])
 
     def test_create_instruction_uncategorized(self):
         self.use_case.create_instruction(


### PR DESCRIPTION
- Implemented an export method in ProjectInstructionsViewSet to allow downloading project instructions as a CSV file.
- Created a build_instructions_csv method in ProjectInstructionsUseCase to generate a flat list of instructions for the CSV.
- Updated URL routing to include a new endpoint for exporting instructions.
- Added tests to validate the CSV export functionality, ensuring correct content and handling of edge cases.