### PR TITLE
Refactor: Replace logger `extra` dicts with inline f-strings

### DIFF
--- a/inline_agents/backends/openai/sessions.py
+++ b/inline_agents/backends/openai/sessions.py
@@ -101,7 +101,7 @@ class RedisSession:  # type: ignore[misc]
         read_client: Optional[redis.Redis] = None,
         write_client: Optional[redis.Redis] = None,
     ):
-        logger.debug("RedisSession", extra={"session_id": session_id})
+        logger.debug("RedisSession", f"session_id: {session_id}")
         self._key = session_id
         self._write_client = write_client if write_client is not None else r
         self._read_client = read_client if read_client is not None else r
@@ -137,7 +137,7 @@ class RedisSession:  # type: ignore[misc]
 
     async def get_items(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         limit = limit or self.limit
-        logger.debug("Session limit", extra={"limit": limit})
+        logger.debug("Session limit", f"limit: {limit}")
         try:
             read_client = self._read_client
             write_client = self._write_client
@@ -225,7 +225,7 @@ class RedisSession:  # type: ignore[misc]
                     )
                     continue
 
-            logger.debug("Session items", extra={"count": len(items)})
+            logger.debug("Session items", f"count: {len(items)}")
             return items
 
         except redis.RedisError as e:

--- a/inline_agents/backends/tests/test_adapter.py
+++ b/inline_agents/backends/tests/test_adapter.py
@@ -61,7 +61,7 @@ class TestBedrockAdapter(TestCase):
         external_team = self.team_adapter.to_external(
             self.supervisor_dict, self.agents_dict, "Hello, how are you?", self.contact_urn, self.project.uuid
         )
-        logger.debug("External team in test", extra={"keys": list(external_team.keys())})
+        logger.debug("External team in test", f"keys: {list(external_team.keys())}")
 
     def test_handle_rationale_in_response(self):
         rationale_text = "This is a rationale text"

--- a/nexus/actions/tests.py
+++ b/nexus/actions/tests.py
@@ -424,7 +424,7 @@ class TemplateActionViewSetTestCase(TestCase):
             project_uuid=str(self.project.uuid),
         )
         response.render()
-        logger.info("Response content rendered", extra={"length": len(response.content or b"")})
+        logger.info("Response content rendered", f"length: {len(response.content or b'')}")
         self.assertEqual(response.status_code, 200)
 
 

--- a/nexus/agents/api/inline_trace_response.py
+++ b/nexus/agents/api/inline_trace_response.py
@@ -40,7 +40,7 @@ def remap_inline_traces_config_agent_names(traces: list[Any], *, project_uuid: s
     except Exception:
         logger.exception(
             "inline trace agentName remap skipped (returning raw traces)",
-            extra={"project_uuid": project_uuid},
+            f"project_uuid: {project_uuid}",
         )
         return traces
 

--- a/nexus/agents/api/views.py
+++ b/nexus/agents/api/views.py
@@ -100,12 +100,12 @@ class PushAgents(APIView):
 
                     credential.agents.add(agent)
 
-                    logger.debug("Credential key", extra={"key": key})
+                    logger.debug("Credential key", f"key: {key}")
 
                 except Exception as e:
                     error_message = str(e)
                     warnings.append(f"Error processing credential '{key}': {error_message}")
-                    logger.error("Error processing credential", extra={"key": key, "error": error_message})
+                    logger.error("Error processing credential", f"key: {key}, error: {error_message}")
                     continue
 
         logger.info("Agent Credentials end")
@@ -638,7 +638,7 @@ class AgentTracesView(APIView):
         project_uuid = request.query_params.get("project_uuid")
         log_id = request.query_params.get("log_id")
 
-        logger.debug("Log retrieve", extra={"project_uuid": project_uuid, "log_id": log_id})
+        logger.debug("Log retrieve", f"project_uuid: {project_uuid}, log_id: {log_id}")
 
         if not log_id:
             return Response({"error": "log_id is required"}, status=400)

--- a/nexus/event_domain/event_manager.py
+++ b/nexus/event_domain/event_manager.py
@@ -94,7 +94,7 @@ class EventManager:
             try:
                 self.validators[event].validate(event, kwargs)
             except Exception as e:
-                logger.error(f"Event '{event}' validation failed: {e}", extra={"event": event, "kwargs": kwargs})
+                logger.error(f"Event '{event}' validation failed: {e}", f"event: {event}, kwargs: {kwargs}")
                 raise
 
         # Get observers from registry only (subscribe() registers all observers there)
@@ -126,12 +126,8 @@ class EventManager:
 
                     logger.error(
                         f"Observer '{observer_name}' failed for event '{event}' (isolated): {e}",
+                        f"observer: {observer_name}, event: {event}, kwargs: {kwargs}",
                         exc_info=True,
-                        extra={
-                            "event": event,
-                            "observer": observer_name,
-                            "kwargs": kwargs,
-                        },
                     )
                     # Continue with next observer
             else:
@@ -232,7 +228,7 @@ class AsyncEventManager:
             try:
                 self.validators[event].validate(event, kwargs)
             except Exception as e:
-                logger.error(f"Event '{event}' validation failed: {e}", extra={"event": event, "kwargs": kwargs})
+                logger.error(f"Event '{event}' validation failed: {e}", f"event: {event}, kwargs: {kwargs}")
                 raise
 
         # Get observers from registry only (subscribe() registers all observers there)
@@ -267,12 +263,8 @@ class AsyncEventManager:
 
                     logger.error(
                         f"Observer '{observer_name}' failed for event '{event}' (isolated): {e}",
+                        f"observer: {observer_name}, event: {event}, kwargs: {kwargs}",
                         exc_info=True,
-                        extra={
-                            "event": event,
-                            "observer": observer_name,
-                            "kwargs": kwargs,
-                        },
                     )
                     # Continue with next observer
             else:

--- a/nexus/event_domain/middleware.py
+++ b/nexus/event_domain/middleware.py
@@ -197,21 +197,12 @@ class PerformanceLoggingMiddleware(ObserverMiddleware):
             logger.warning(
                 f"Slow observer execution: '{observer_name}' for event '{event}' "
                 f"took {duration:.3f}s (threshold: {self.slow_threshold}s)",
-                extra={
-                    "observer": observer_name,
-                    "event": event,
-                    "duration": duration,
-                    "slow": True,
-                },
+                f"observer: {observer_name}, event: {event}, duration: {duration}, slow: True",
             )
         else:
             logger.debug(
                 f"Observer '{observer_name}' for event '{event}' took {duration:.3f}s",
-                extra={
-                    "observer": observer_name,
-                    "event": event,
-                    "duration": duration,
-                },
+                f"observer: {observer_name}, event: {event}, duration: {duration}",
             )
 
     def on_error(self, observer, event: str, error: Exception, duration: float, **kwargs) -> None:
@@ -222,12 +213,7 @@ class PerformanceLoggingMiddleware(ObserverMiddleware):
         observer_name = getattr(observer.__class__, "__name__", "Unknown")
         logger.debug(
             f"Observer '{observer_name}' for event '{event}' failed after {duration:.3f}s",
-            extra={
-                "observer": observer_name,
-                "event": event,
-                "duration": duration,
-                "error": True,
-            },
+            f"observer: {observer_name}, event: {event}, duration: {duration}, error: True",
         )
 
 

--- a/nexus/event_domain/validators.py
+++ b/nexus/event_domain/validators.py
@@ -162,6 +162,6 @@ class ValidatorChain:
             except Exception as e:
                 logger.warning(
                     f"Event '{event}' validation failed: {e}",
-                    extra={"event": event, "payload_keys": list(payload.keys())},
+                    f"event: {event}, payload_keys: {list(payload.keys())}",
                 )
                 raise


### PR DESCRIPTION
### TL;DR

Migrated logger calls from using the `extra={}` keyword argument to passing context as a positional f-string argument.

### What changed?

All `logger.debug`, `logger.info`, `logger.warning`, and `logger.error` calls that previously passed structured context via `extra={"key": value}` have been updated to pass that context as a formatted string positional argument (e.g., `f"key: {value}"`). This affects logging across the Redis session handler, event manager, event middleware, validators, agent views, and test files.

### How to test?

Run the existing test suite to confirm no regressions. Verify that log output still contains the expected contextual information in the new inline string format.

### Why make this change?

The `extra` keyword in Python's standard logger injects fields into the `LogRecord`, which requires downstream log handlers to be explicitly configured to surface those fields. Passing context as a positional string argument ensures the information is always visible in the log message itself, regardless of the logging backend or formatter in use.