### PR TITLE
feat: add last_updated from latest CLI version to my-agents endpoint

### DIFF
--- a/nexus/agents/api/test_agents_api.py
+++ b/nexus/agents/api/test_agents_api.py
@@ -71,7 +71,30 @@ class AgentViewsetSetTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(content), 2)
         for row in content:
-            self.assertNotIn("last_updated", row)
+            self.assertIn("last_updated", row)
+            self.assertIsNone(row["last_updated"])
+
+    def test_get_my_agents_last_updated_from_latest_cli_version(self):
+        from nexus.inline_agents.api.serializers.catalog import format_agent_last_updated
+
+        older = timezone.now() - timedelta(days=2)
+        newer = timezone.now() - timedelta(hours=1)
+        v1 = Version.objects.create(skills=[], display_skills=[], agent=self.agent)
+        v2 = Version.objects.create(skills=[], display_skills=[], agent=self.agent)
+        Version.objects.filter(pk=v1.pk).update(created_on=older)
+        Version.objects.filter(pk=v2.pk).update(created_on=newer)
+        expected = format_agent_last_updated(
+            Version.objects.filter(agent=self.agent).aggregate(last=Max("created_on"))["last"]
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("my-agents", kwargs={"project_uuid": str(self.project.uuid)})
+        response = client.get(url)
+        response.render()
+        content = json.loads(response.content)
+        row = next(r for r in content if r["uuid"] == str(self.agent.uuid))
+        self.assertEqual(row["last_updated"], expected)
 
     def test_get_my_agents_with_search(self):
         query_params = {"search": "information"}
@@ -1420,6 +1443,12 @@ class CatalogRowKeyParityTestCase(TestCase):
         self.assertNotIn("agents", row)
         self.assertNotIn("last_updated", row)
 
+    def _assert_my_agents_row_keys(self, row: dict) -> None:
+        from nexus.inline_agents.api.serializers.catalog import MY_AGENTS_LAST_UPDATED_KEY
+
+        self.assertEqual(frozenset(row.keys()), self.expected_keys | {MY_AGENTS_LAST_UPDATED_KEY})
+        self.assertNotIn("agents", row)
+
     def test_my_agents_uses_catalog_row_keys(self):
         client = APIClient()
         client.force_authenticate(user=self.user)
@@ -1428,7 +1457,7 @@ class CatalogRowKeyParityTestCase(TestCase):
         my_resp = client.get(reverse("my-agents", kwargs={"project_uuid": project_uuid}))
         my_resp.render()
         my_row = next(r for r in json.loads(my_resp.content) if r["uuid"] == str(self.agent.uuid))
-        self._assert_catalog_row_keys(my_row)
+        self._assert_my_agents_row_keys(my_row)
 
     def test_team_roster_includes_last_updated(self):
         client = APIClient()
@@ -1462,7 +1491,7 @@ class CatalogRowKeyParityTestCase(TestCase):
         group_row = next(r for r in _official_v1_grouped_rows(resp.json()) if r["group"] == self.group.slug)
         self._assert_catalog_row_keys(group_row)
         self.assertEqual(group_row["name"], "Parity Display")
-        self._assert_catalog_row_keys(my_row)
+        self._assert_my_agents_row_keys(my_row)
         self.assertNotIn("last_updated", group_row)
 
 

--- a/nexus/inline_agents/api/serializers/catalog.py
+++ b/nexus/inline_agents/api/serializers/catalog.py
@@ -59,12 +59,21 @@ CATALOG_ROW_KEYS: frozenset[str] = frozenset(
 # Backward-compatible alias for tests/imports.
 CATALOG_AGENT_ROW_KEYS = CATALOG_ROW_KEYS
 
+MY_AGENTS_LAST_UPDATED_KEY = "last_updated"
+
 
 def format_agent_last_updated(value: datetime | None) -> str | None:
     """ISO-8601 timestamp for the latest CLI push version, or ``None`` when never pushed."""
     if value is None:
         return None
     return pendulum.instance(value).in_timezone("UTC").to_iso8601_string()
+
+
+def enrich_my_agents_row(row: dict[str, Any], agent: Agent) -> dict[str, Any]:
+    """Add ``last_updated`` from queryset annotation ``last_version_at`` (``Max(versions__created_on)``)."""
+    last_version_at = getattr(agent, "last_version_at", None)
+    row[MY_AGENTS_LAST_UPDATED_KEY] = format_agent_last_updated(last_version_at)
+    return row
 
 
 def project_agent_assignment_map(

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -28,6 +28,7 @@ from nexus.inline_agents.api.serializers import (
 )
 from nexus.inline_agents.api.serializers.catalog import (
     build_row_from_project_agent,
+    enrich_my_agents_row,
     my_agents_list_prefetches,
     project_agent_assignment_map,
 )
@@ -684,7 +685,11 @@ class AgentsView(APIView):
         project_uuid = kwargs.get("project_uuid")
         search = self.request.query_params.get("search")
 
-        agents = Agent.objects.filter(project__uuid=project_uuid).select_related("group", "group__modal")
+        agents = (
+            Agent.objects.filter(project__uuid=project_uuid)
+            .select_related("group", "group__modal")
+            .annotate(last_version_at=Max("versions__created_on"))
+        )
 
         if search:
             query_filter = (
@@ -699,11 +704,14 @@ class AgentsView(APIView):
             project_agent_assignment_map(str(project_uuid), include_inactive_integrated=False) if project_uuid else None
         )
         data = [
-            build_row_from_project_agent(
+            enrich_my_agents_row(
+                build_row_from_project_agent(
+                    agent,
+                    project_uuid,
+                    include_inactive_integrated=False,
+                    assignment_by_agent_id=assignment,
+                ),
                 agent,
-                project_uuid,
-                include_inactive_integrated=False,
-                assignment_by_agent_id=assignment,
             )
             for agent in agents
         ]


### PR DESCRIPTION
The "my agents" endpoint now returns a `last_updated` field reflecting the most recent CLI push (version creation) for each agent.

### What changed?

- The `MyAgentsView` queryset now annotates each agent with `last_version_at` using `Max("versions__created_on")`.
- A new `enrich_my_agents_row` helper reads that annotation and appends `last_updated` (ISO-8601 formatted, UTC) to each row in the response. When no versions exist, the field is present but `null`.
- A `MY_AGENTS_LAST_UPDATED_KEY` constant (`"last_updated"`) is exported from the catalog serializer module for use in tests and assertions.
- Tests are updated to assert that `last_updated` is present in every "my agents" row, verify it is `null` when no versions exist, and confirm it equals the formatted timestamp of the newest version when multiple versions are present.

### Why make this change?

Consumers of the "my agents" endpoint need to know when an agent was last updated via a CLI push. Surfacing `last_updated` directly in the list response avoids additional round-trips and keeps the field consistent with how it is already exposed in the team roster endpoint.