### PR TITLE
feat: inject progressive feedback orchestration instruction into supervisor prompts

### DIFF
--- a/contrib/gen_env.py
+++ b/contrib/gen_env.py
@@ -197,6 +197,10 @@ def generate_env():
         "INVOKE_AGENTS_RATE_LIMIT": "2500/m",
         "RATIONALE_IMPROVEMENT_INSTRUCTIONS": "",
         "SUBSEQUENT_RATIONALE_INSTRUCTIONS": "",
+        "PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION": (
+            "Before executing ANY tool or calling an agent, send the user a short feedback message "
+            "explaining what you're about to do, so they know the request is being processed."
+        ),
         "COMPLEXITY_LAYER_LAMBDA": "lambda-complexity-layer",
         "AWS_COMPONENTS_FUNCTION_ARN": "",
         "FORMATTER_AGENT_MODEL": "gpt-4.1-mini",

--- a/inline_agents/backends/bedrock/backend.py
+++ b/inline_agents/backends/bedrock/backend.py
@@ -18,6 +18,10 @@ from nexus.projects.websockets.consumers import (
 from nexus.usecases.inline_agents.typing import TypingUsecase
 from nexus.usecases.jwt.jwt_usecase import JWTUsecase
 from router.handler import PostMessageHandler
+from router.traces_observers.rationale.channel_hint import (
+    channel_hint_from_contact_urn,
+    supports_progressive_feedback,
+)
 from router.traces_observers.save_traces import save_inline_message_to_database
 
 from .adapter import BedrockDataLakeEventAdapter, BedrockTeamAdapter
@@ -138,7 +142,24 @@ class BedrockBackend(InlineAgentsBackend):
         **kwargs,
     ):
         skip_conversation_sqs = kwargs.pop("skip_conversation_sqs", False)
+        channel_type = kwargs.pop("channel_type", "")
         supervisor = self.supervisor_repository.get_supervisor(project=project, foundation_model=foundation_model)
+
+        progressive_feedback_enabled = rationale_switch and supports_progressive_feedback(
+            contact_urn,
+            channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
+        )
+        if rationale_switch and not progressive_feedback_enabled:
+            logger.info(
+                "[ProgressiveFeedback] Disabled for non-webchat channel project_uuid=%s "
+                "channel_from_urn=%s contact_urn=%s channel_type=%s",
+                project_uuid,
+                channel_hint_from_contact_urn(contact_urn),
+                contact_urn,
+                channel_type or None,
+            )
 
         # Set dependencies
         self._event_manager_notify = event_manager_notify or self._get_event_manager_notify()
@@ -293,13 +314,14 @@ class BedrockBackend(InlineAgentsBackend):
                     send_message_callback=None,
                     preview=preview,
                     preview_websocket=preview_websocket,
-                    rationale_switch=rationale_switch,
+                    rationale_switch=progressive_feedback_enabled,
                     language=language,
                     user_email=user_email,
                     session_id=session_id,
                     msg_external_id=msg_external_id,
                     turn_off_rationale=turn_off_rationale,
                     channel_uuid=channel_uuid,
+                    channel_type=channel_type,
                 )
 
                 if "rationale" in orchestration_trace and msg_external_id and not preview:

--- a/inline_agents/backends/openai/adapter.py
+++ b/inline_agents/backends/openai/adapter.py
@@ -218,6 +218,7 @@ class OpenAITeamAdapter(TeamAdapter):
         turn_off_rationale: bool,
         skip_conversation_sqs: bool = False,
         manager_pipeline_version: Optional[str] = None,
+        channel_type: str = "",
     ):
         supervisor_instructions: str = cls.prepare_instructions(instructions)
         llm_formatted_time: str = cls.prepare_time()
@@ -252,6 +253,9 @@ class OpenAITeamAdapter(TeamAdapter):
             include_streaming_merge_prompts=bool(use_components and not is_legacy_manager_pipeline),
             rationale_switch=rationale_switch,
             turn_off_rationale=turn_off_rationale,
+            channel_type=channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
         )
 
         agents_as_tools: List[CollaboratorEntity] = cls.build_agents(
@@ -362,6 +366,7 @@ class OpenAITeamAdapter(TeamAdapter):
         turn_off_rationale: bool = False,
         use_components: bool = False,
         skip_conversation_sqs: bool = False,
+        channel_type: str = "",
         # Cached data parameters (optional, used to avoid database queries)
         content_base_uuid: str = None,
         business_rules: str = None,
@@ -416,6 +421,9 @@ class OpenAITeamAdapter(TeamAdapter):
             include_streaming_merge_prompts=False,
             rationale_switch=rationale_switch,
             turn_off_rationale=turn_off_rationale,
+            channel_type=channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
         )
 
         for agent in agents:
@@ -1087,6 +1095,9 @@ class OpenAITeamAdapter(TeamAdapter):
         include_streaming_merge_prompts: bool = False,
         rationale_switch: bool = False,
         turn_off_rationale: bool = False,
+        channel_type: str = "",
+        preview: bool = False,
+        preview_websocket: bool = False,
     ) -> str:
         general_context_data = {
             "PROJECT_ID": project_id,
@@ -1145,18 +1156,62 @@ class OpenAITeamAdapter(TeamAdapter):
         rendered_content = template.render(context_object)
 
         from inline_agents.backends.openai.prompts_progressive_feedback import (
+            find_core_identity_marker,
             get_progressive_feedback_orchestration_instruction,
             inject_progressive_feedback_instruction,
+            log_progressive_feedback_orchestration_decision,
             should_inject_progressive_feedback_instruction,
         )
 
-        if should_inject_progressive_feedback_instruction(rationale_switch, turn_off_rationale):
+        if should_inject_progressive_feedback_instruction(
+            rationale_switch,
+            turn_off_rationale,
+            contact_urn=contact_id,
+            channel_type=channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
+        ):
             progressive_feedback_instruction = get_progressive_feedback_orchestration_instruction()
             if progressive_feedback_instruction:
+                insertion_point = find_core_identity_marker(rendered_content) or "prepend"
                 rendered_content = inject_progressive_feedback_instruction(
                     rendered_content,
                     progressive_feedback_instruction,
                 )
+                log_progressive_feedback_orchestration_decision(
+                    project_id=project_id,
+                    contact_urn=contact_id,
+                    channel_type=channel_type,
+                    preview=preview,
+                    preview_websocket=preview_websocket,
+                    rationale_switch=rationale_switch,
+                    turn_off_rationale=turn_off_rationale,
+                    injected=True,
+                    insertion_point=insertion_point,
+                    instruction_preview=progressive_feedback_instruction[:120],
+                )
+            else:
+                log_progressive_feedback_orchestration_decision(
+                    project_id=project_id,
+                    contact_urn=contact_id,
+                    channel_type=channel_type,
+                    preview=preview,
+                    preview_websocket=preview_websocket,
+                    rationale_switch=rationale_switch,
+                    turn_off_rationale=turn_off_rationale,
+                    injected=False,
+                )
+        else:
+            log_progressive_feedback_orchestration_decision(
+                project_id=project_id,
+                contact_urn=contact_id,
+                channel_type=channel_type,
+                preview=preview,
+                preview_websocket=preview_websocket,
+                rationale_switch=rationale_switch,
+                turn_off_rationale=turn_off_rationale,
+                injected=False,
+            )
 
         return rendered_content
 

--- a/inline_agents/backends/openai/adapter.py
+++ b/inline_agents/backends/openai/adapter.py
@@ -250,6 +250,8 @@ class OpenAITeamAdapter(TeamAdapter):
             components_instructions_up=supervisor.get("components_instructions_up", ""),
             human_support_instructions=supervisor.get("human_support_instructions", ""),
             include_streaming_merge_prompts=bool(use_components and not is_legacy_manager_pipeline),
+            rationale_switch=rationale_switch,
+            turn_off_rationale=turn_off_rationale,
         )
 
         agents_as_tools: List[CollaboratorEntity] = cls.build_agents(
@@ -274,9 +276,7 @@ class OpenAITeamAdapter(TeamAdapter):
         json_tools = cls._get_tools(supervisor["tools"])
         if not use_components:
             component_tool_names_to_strip = all_component_tool_names(formatter_tools_descriptions)
-            json_tools = [
-                t for t in json_tools if getattr(t, "name", None) not in component_tool_names_to_strip
-            ]
+            json_tools = [t for t in json_tools if getattr(t, "name", None) not in component_tool_names_to_strip]
 
         supervisor_tools: List[Any] = list(json_tools)
         supervisor_tools.extend(agents_as_tools)
@@ -289,12 +289,8 @@ class OpenAITeamAdapter(TeamAdapter):
             legacy_component_tool_name_set = all_component_tool_names(formatter_tools_descriptions)
             streaming_merge_tool_name_set = streaming_merge_tool_names(formatter_tools_descriptions)
             names_to_strip = legacy_component_tool_name_set | streaming_merge_tool_name_set
-            supervisor_tools = [
-                t for t in supervisor_tools if getattr(t, "name", None) not in names_to_strip
-            ]
-            supervisor_tools.extend(
-                get_supervisor_component_tools_for_streaming_merge(formatter_tools_descriptions)
-            )
+            supervisor_tools = [t for t in supervisor_tools if getattr(t, "name", None) not in names_to_strip]
+            supervisor_tools.extend(get_supervisor_component_tools_for_streaming_merge(formatter_tools_descriptions))
 
         supervisor_agent = SupervisorEntity(
             name="manager",
@@ -418,6 +414,8 @@ class OpenAITeamAdapter(TeamAdapter):
             components_instructions_up=supervisor.get("components_instructions_up", ""),
             human_support_instructions=supervisor.get("human_support_instructions", ""),
             include_streaming_merge_prompts=False,
+            rationale_switch=rationale_switch,
+            turn_off_rationale=turn_off_rationale,
         )
 
         for agent in agents:
@@ -1087,6 +1085,8 @@ class OpenAITeamAdapter(TeamAdapter):
         components_instructions_up,
         human_support_instructions,
         include_streaming_merge_prompts: bool = False,
+        rationale_switch: bool = False,
+        turn_off_rationale: bool = False,
     ) -> str:
         general_context_data = {
             "PROJECT_ID": project_id,
@@ -1143,6 +1143,20 @@ class OpenAITeamAdapter(TeamAdapter):
         context_object = TemplateContext(context_data)
 
         rendered_content = template.render(context_object)
+
+        from inline_agents.backends.openai.prompts_progressive_feedback import (
+            get_progressive_feedback_orchestration_instruction,
+            inject_progressive_feedback_instruction,
+            should_inject_progressive_feedback_instruction,
+        )
+
+        if should_inject_progressive_feedback_instruction(rationale_switch, turn_off_rationale):
+            progressive_feedback_instruction = get_progressive_feedback_orchestration_instruction()
+            if progressive_feedback_instruction:
+                rendered_content = inject_progressive_feedback_instruction(
+                    rendered_content,
+                    progressive_feedback_instruction,
+                )
 
         return rendered_content
 

--- a/inline_agents/backends/openai/backend.py
+++ b/inline_agents/backends/openai/backend.py
@@ -47,6 +47,10 @@ from nexus.inline_agents.models import InlineAgentsConfiguration
 from nexus.internals.connect import ConnectRESTClient
 from nexus.projects.websockets.consumers import send_preview_message_to_websocket
 from nexus.usecases.jwt.jwt_usecase import JWTUsecase
+from router.traces_observers.rationale.channel_hint import (
+    channel_hint_from_contact_urn,
+    supports_progressive_feedback,
+)
 from router.traces_observers.save_traces import save_inline_message_async
 from router.utils.redis_clients import get_redis_read_client, get_redis_write_client
 
@@ -275,6 +279,21 @@ class OpenAIBackend(InlineAgentsBackend):
         manager_pipeline_version = kwargs.pop("manager_pipeline_version", None)
         supervisor_agent_uuid = kwargs.pop("supervisor_agent_uuid", None)
         rationale_switch = rationale_switch_cached
+        progressive_feedback_enabled = rationale_switch and supports_progressive_feedback(
+            contact_urn,
+            channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
+        )
+        if rationale_switch and not progressive_feedback_enabled:
+            logger.info(
+                "[ProgressiveFeedback] Disabled for non-webchat channel project_uuid=%s "
+                "channel_from_urn=%s contact_urn=%s channel_type=%s",
+                project_uuid,
+                channel_hint_from_contact_urn(contact_urn),
+                contact_urn,
+                channel_type or None,
+            )
         if manager_pipeline_version is not None:
             logger.debug(
                 "[OpenAIBackend] manager_pipeline_version=%s project_uuid=%s",
@@ -337,7 +356,7 @@ class OpenAIBackend(InlineAgentsBackend):
             agent_name="manager",
             preview=preview,
             preview_websocket=preview_websocket,
-            rationale_switch=rationale_switch,
+            rationale_switch=progressive_feedback_enabled,
             language=language,
             user_email=user_email,
             session_id=session_id,
@@ -360,7 +379,7 @@ class OpenAIBackend(InlineAgentsBackend):
             supervisor_name="manager",
             preview=preview,
             preview_websocket=preview_websocket,
-            rationale_switch=rationale_switch,
+            rationale_switch=progressive_feedback_enabled,
             language=language,
             user_email=user_email,
             session_id=session_id,
@@ -414,6 +433,7 @@ class OpenAIBackend(InlineAgentsBackend):
                 turn_off_rationale=turn_off_rationale,
                 skip_conversation_sqs=skip_conversation_sqs,
                 manager_pipeline_version=manager_pipeline_version,
+                channel_type=channel_type,
             )
         else:
             external_team = self.team_adapter.to_external(
@@ -450,6 +470,7 @@ class OpenAIBackend(InlineAgentsBackend):
                 auth_token=auth_token,
                 use_components=use_components_cached,
                 skip_conversation_sqs=skip_conversation_sqs,
+                channel_type=channel_type,
             )
 
         client = self._get_client()

--- a/inline_agents/backends/openai/prompts_progressive_feedback.py
+++ b/inline_agents/backends/openai/prompts_progressive_feedback.py
@@ -1,0 +1,38 @@
+"""Runtime-only progressive feedback instruction injected during orchestration."""
+
+from django.conf import settings
+
+DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION = (
+    "Before executing ANY tool or calling an agent, send the user a short feedback message "
+    "explaining what you're about to do, so they know the request is being processed."
+)
+
+CORE_IDENTITY_MARKERS = ("<core_identity>", "## Core Identity")
+
+
+def get_progressive_feedback_orchestration_instruction() -> str:
+    return getattr(settings, "PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION", "") or ""
+
+
+def should_inject_progressive_feedback_instruction(
+    rationale_switch: bool,
+    turn_off_rationale: bool,
+) -> bool:
+    return rationale_switch and not turn_off_rationale
+
+
+def inject_progressive_feedback_instruction(rendered_prompt: str, instruction: str) -> str:
+    instruction = instruction.strip()
+    if not instruction:
+        return rendered_prompt
+
+    for marker in CORE_IDENTITY_MARKERS:
+        idx = rendered_prompt.find(marker)
+        if idx != -1:
+            prefix = rendered_prompt[:idx].rstrip()
+            suffix = rendered_prompt[idx:]
+            if prefix:
+                return f"{prefix}\n\n{instruction}\n\n{suffix}"
+            return f"{instruction}\n\n{suffix}"
+
+    return f"{instruction}\n\n{rendered_prompt}"

--- a/inline_agents/backends/openai/prompts_progressive_feedback.py
+++ b/inline_agents/backends/openai/prompts_progressive_feedback.py
@@ -1,6 +1,15 @@
 """Runtime-only progressive feedback instruction injected during orchestration."""
 
+import logging
+
 from django.conf import settings
+
+from router.traces_observers.rationale.channel_hint import (
+    channel_hint_from_contact_urn,
+    supports_progressive_feedback,
+)
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION = (
     "Before executing ANY tool or calling an agent, send the user a short feedback message "
@@ -17,8 +26,28 @@ def get_progressive_feedback_orchestration_instruction() -> str:
 def should_inject_progressive_feedback_instruction(
     rationale_switch: bool,
     turn_off_rationale: bool,
+    contact_urn: str = "",
+    channel_type: str = "",
+    preview: bool = False,
+    preview_websocket: bool = False,
 ) -> bool:
-    return rationale_switch and not turn_off_rationale
+    return (
+        rationale_switch
+        and not turn_off_rationale
+        and supports_progressive_feedback(
+            contact_urn,
+            channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
+        )
+    )
+
+
+def find_core_identity_marker(prompt: str) -> str | None:
+    for marker in CORE_IDENTITY_MARKERS:
+        if marker in prompt:
+            return marker
+    return None
 
 
 def inject_progressive_feedback_instruction(rendered_prompt: str, instruction: str) -> str:
@@ -36,3 +65,66 @@ def inject_progressive_feedback_instruction(rendered_prompt: str, instruction: s
             return f"{instruction}\n\n{suffix}"
 
     return f"{instruction}\n\n{rendered_prompt}"
+
+
+def log_progressive_feedback_orchestration_decision(
+    *,
+    project_id: str,
+    rationale_switch: bool,
+    turn_off_rationale: bool,
+    injected: bool,
+    contact_urn: str = "",
+    channel_type: str = "",
+    preview: bool = False,
+    preview_websocket: bool = False,
+    insertion_point: str | None = None,
+    instruction_preview: str | None = None,
+) -> None:
+    channel_from_urn = channel_hint_from_contact_urn(contact_urn) if contact_urn else None
+    if injected:
+        logger.info(
+            "[ProgressiveFeedback] Orchestration instruction injected project_id=%s channel_from_urn=%s "
+            "contact_urn=%s insertion_point=%s instruction_preview=%r",
+            project_id,
+            channel_from_urn,
+            contact_urn or None,
+            insertion_point,
+            instruction_preview,
+        )
+        return
+
+    if not rationale_switch or turn_off_rationale:
+        logger.info(
+            "[ProgressiveFeedback] Orchestration instruction skipped project_id=%s channel_from_urn=%s "
+            "contact_urn=%s rationale_switch=%s turn_off_rationale=%s",
+            project_id,
+            channel_from_urn,
+            contact_urn or None,
+            rationale_switch,
+            turn_off_rationale,
+        )
+        return
+
+    if not supports_progressive_feedback(
+        contact_urn,
+        channel_type,
+        preview=preview,
+        preview_websocket=preview_websocket,
+    ):
+        logger.info(
+            "[ProgressiveFeedback] Orchestration instruction skipped project_id=%s channel_from_urn=%s "
+            "contact_urn=%s channel_type=%s reason=non_webchat",
+            project_id,
+            channel_from_urn,
+            contact_urn or None,
+            channel_type or None,
+        )
+        return
+
+    logger.info(
+        "[ProgressiveFeedback] Orchestration instruction skipped project_id=%s channel_from_urn=%s "
+        "contact_urn=%s reason=empty_instruction",
+        project_id,
+        channel_from_urn,
+        contact_urn or None,
+    )

--- a/inline_agents/backends/openai/tests/test_prompts_progressive_feedback.py
+++ b/inline_agents/backends/openai/tests/test_prompts_progressive_feedback.py
@@ -3,11 +3,20 @@ from django.test import SimpleTestCase, override_settings
 from inline_agents.backends.openai.adapter import OpenAITeamAdapter
 from inline_agents.backends.openai.prompts_progressive_feedback import (
     DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION,
+    find_core_identity_marker,
     inject_progressive_feedback_instruction,
     should_inject_progressive_feedback_instruction,
 )
+from router.traces_observers.rationale.channel_hint import (
+    channel_hint_from_contact_urn,
+    is_webchat_channel,
+    supports_progressive_feedback,
+)
 
 TEST_INSTRUCTION = "Send progressive feedback before tools."
+WEBCHAT_CONTACT_URN = "project-abc-session-ext:212034573131@webchat.ai.test"
+AMERICANAS_WEBCHAT_CONTACT_URN = "ext:1486635309559@www.americanas.com.br"
+WHATSAPP_CONTACT_URN = "whatsapp:5511999999999"
 CORE_IDENTITY_XML_PROMPT = "# Manager\n\n" "<core_identity>\n" "You are a customer service leader.\n" "</core_identity>"
 CORE_IDENTITY_MARKDOWN_PROMPT = (
     "# Customer Service Assistant\n\n" "## Core Identity\n" "You are a customer service leader."
@@ -15,15 +24,88 @@ CORE_IDENTITY_MARKDOWN_PROMPT = (
 NO_MARKER_PROMPT = "# Manager\n\nYou are a customer service leader."
 
 
+class TestChannelHintFromContactUrn(SimpleTestCase):
+    def test_webchat_ext_urn(self):
+        self.assertEqual(channel_hint_from_contact_urn(AMERICANAS_WEBCHAT_CONTACT_URN), "web")
+
+    def test_webchat_domain_urn(self):
+        self.assertEqual(channel_hint_from_contact_urn(WEBCHAT_CONTACT_URN), "web")
+
+    def test_non_webchat_urn_uses_prefix(self):
+        self.assertEqual(channel_hint_from_contact_urn(WHATSAPP_CONTACT_URN), "whatsapp")
+
+    def test_unknown_when_empty(self):
+        self.assertEqual(channel_hint_from_contact_urn(""), "unknown")
+
+
+class TestSupportsProgressiveFeedback(SimpleTestCase):
+    def test_americanas_webchat_urn_supported(self):
+        self.assertTrue(supports_progressive_feedback(AMERICANAS_WEBCHAT_CONTACT_URN))
+
+    def test_webchat_urn_supported(self):
+        self.assertTrue(supports_progressive_feedback(WEBCHAT_CONTACT_URN))
+
+    def test_wwc_channel_type_supported(self):
+        self.assertTrue(supports_progressive_feedback("contact-1", "WWC"))
+
+    def test_non_webchat_not_supported(self):
+        self.assertFalse(supports_progressive_feedback(WHATSAPP_CONTACT_URN))
+
+    def test_preview_bypasses_channel_restriction(self):
+        self.assertTrue(supports_progressive_feedback(WHATSAPP_CONTACT_URN, preview=True))
+
+    def test_is_webchat_channel(self):
+        self.assertTrue(is_webchat_channel(AMERICANAS_WEBCHAT_CONTACT_URN))
+        self.assertFalse(is_webchat_channel(WHATSAPP_CONTACT_URN))
+
+
+class TestFindCoreIdentityMarker(SimpleTestCase):
+    def test_finds_xml_marker(self):
+        self.assertEqual(find_core_identity_marker(CORE_IDENTITY_XML_PROMPT), "<core_identity>")
+
+    def test_finds_markdown_marker(self):
+        self.assertEqual(find_core_identity_marker(CORE_IDENTITY_MARKDOWN_PROMPT), "## Core Identity")
+
+    def test_returns_none_when_marker_missing(self):
+        self.assertIsNone(find_core_identity_marker(NO_MARKER_PROMPT))
+
+
 class TestShouldInjectProgressiveFeedbackInstruction(SimpleTestCase):
-    def test_injects_when_rationale_enabled(self):
-        self.assertTrue(should_inject_progressive_feedback_instruction(True, False))
+    def test_injects_when_rationale_enabled_on_webchat(self):
+        self.assertTrue(
+            should_inject_progressive_feedback_instruction(
+                True,
+                False,
+                contact_urn=WEBCHAT_CONTACT_URN,
+            )
+        )
+
+    def test_skips_on_non_webchat(self):
+        self.assertFalse(
+            should_inject_progressive_feedback_instruction(
+                True,
+                False,
+                contact_urn=WHATSAPP_CONTACT_URN,
+            )
+        )
 
     def test_skips_when_rationale_disabled(self):
-        self.assertFalse(should_inject_progressive_feedback_instruction(False, False))
+        self.assertFalse(
+            should_inject_progressive_feedback_instruction(
+                False,
+                False,
+                contact_urn=WEBCHAT_CONTACT_URN,
+            )
+        )
 
     def test_skips_when_turn_off_rationale(self):
-        self.assertFalse(should_inject_progressive_feedback_instruction(True, True))
+        self.assertFalse(
+            should_inject_progressive_feedback_instruction(
+                True,
+                True,
+                contact_urn=WEBCHAT_CONTACT_URN,
+            )
+        )
 
 
 class TestInjectProgressiveFeedbackInstruction(SimpleTestCase):
@@ -64,7 +146,7 @@ class TestGetSupervisorInstructionsProgressiveFeedback(SimpleTestCase):
             "supervisor_instructions": "",
             "business_rules": "",
             "project_id": "proj-1",
-            "contact_id": "contact-1",
+            "contact_id": WEBCHAT_CONTACT_URN,
             "contact_name": "Alex",
             "channel_uuid": "channel-1",
             "content_base_uuid": "content-1",
@@ -114,6 +196,24 @@ class TestGetSupervisorInstructionsProgressiveFeedback(SimpleTestCase):
         result = self._call_get_supervisor_instructions(rationale_switch=True)
 
         self.assertNotIn(DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION, result)
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_injects_for_americanas_webchat_urn(self):
+        result = self._call_get_supervisor_instructions(
+            rationale_switch=True,
+            contact_id=AMERICANAS_WEBCHAT_CONTACT_URN,
+        )
+
+        self.assertIn(TEST_INSTRUCTION, result)
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_skips_on_non_webchat(self):
+        result = self._call_get_supervisor_instructions(
+            rationale_switch=True,
+            contact_id=WHATSAPP_CONTACT_URN,
+        )
+
+        self.assertNotIn(TEST_INSTRUCTION, result)
 
     @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
     def test_prepends_when_marker_missing(self):

--- a/inline_agents/backends/openai/tests/test_prompts_progressive_feedback.py
+++ b/inline_agents/backends/openai/tests/test_prompts_progressive_feedback.py
@@ -1,0 +1,125 @@
+from django.test import SimpleTestCase, override_settings
+
+from inline_agents.backends.openai.adapter import OpenAITeamAdapter
+from inline_agents.backends.openai.prompts_progressive_feedback import (
+    DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION,
+    inject_progressive_feedback_instruction,
+    should_inject_progressive_feedback_instruction,
+)
+
+TEST_INSTRUCTION = "Send progressive feedback before tools."
+CORE_IDENTITY_XML_PROMPT = "# Manager\n\n" "<core_identity>\n" "You are a customer service leader.\n" "</core_identity>"
+CORE_IDENTITY_MARKDOWN_PROMPT = (
+    "# Customer Service Assistant\n\n" "## Core Identity\n" "You are a customer service leader."
+)
+NO_MARKER_PROMPT = "# Manager\n\nYou are a customer service leader."
+
+
+class TestShouldInjectProgressiveFeedbackInstruction(SimpleTestCase):
+    def test_injects_when_rationale_enabled(self):
+        self.assertTrue(should_inject_progressive_feedback_instruction(True, False))
+
+    def test_skips_when_rationale_disabled(self):
+        self.assertFalse(should_inject_progressive_feedback_instruction(False, False))
+
+    def test_skips_when_turn_off_rationale(self):
+        self.assertFalse(should_inject_progressive_feedback_instruction(True, True))
+
+
+class TestInjectProgressiveFeedbackInstruction(SimpleTestCase):
+    def test_injects_before_core_identity_xml_marker(self):
+        result = inject_progressive_feedback_instruction(CORE_IDENTITY_XML_PROMPT, TEST_INSTRUCTION)
+
+        self.assertIn(f"{TEST_INSTRUCTION}\n\n<core_identity>", result)
+        self.assertLess(result.index(TEST_INSTRUCTION), result.index("<core_identity>"))
+
+    def test_injects_before_core_identity_markdown_marker(self):
+        result = inject_progressive_feedback_instruction(CORE_IDENTITY_MARKDOWN_PROMPT, TEST_INSTRUCTION)
+
+        self.assertIn(f"{TEST_INSTRUCTION}\n\n## Core Identity", result)
+        self.assertLess(result.index(TEST_INSTRUCTION), result.index("## Core Identity"))
+
+    def test_prepends_when_marker_not_found(self):
+        result = inject_progressive_feedback_instruction(NO_MARKER_PROMPT, TEST_INSTRUCTION)
+
+        self.assertTrue(result.startswith(f"{TEST_INSTRUCTION}\n\n# Manager"))
+
+    def test_returns_unchanged_when_instruction_empty(self):
+        self.assertEqual(
+            inject_progressive_feedback_instruction(CORE_IDENTITY_XML_PROMPT, ""),
+            CORE_IDENTITY_XML_PROMPT,
+        )
+
+
+class TestGetSupervisorInstructionsProgressiveFeedback(SimpleTestCase):
+    def _call_get_supervisor_instructions(self, **overrides):
+        defaults = {
+            "instruction": CORE_IDENTITY_XML_PROMPT,
+            "date_time_now": "Today is Monday",
+            "contact_fields": "",
+            "supervisor_name": "Manager",
+            "supervisor_role": "Leader",
+            "supervisor_goal": "Help customers",
+            "supervisor_adjective": "Friendly",
+            "supervisor_instructions": "",
+            "business_rules": "",
+            "project_id": "proj-1",
+            "contact_id": "contact-1",
+            "contact_name": "Alex",
+            "channel_uuid": "channel-1",
+            "content_base_uuid": "content-1",
+            "use_components": False,
+            "use_human_support": False,
+            "components_instructions": "",
+            "components_instructions_up": "",
+            "human_support_instructions": "",
+        }
+        defaults.update(overrides)
+        return OpenAITeamAdapter.get_supervisor_instructions(**defaults)
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_injects_when_rationale_switch_enabled(self):
+        result = self._call_get_supervisor_instructions(rationale_switch=True)
+
+        self.assertIn(TEST_INSTRUCTION, result)
+        self.assertLess(result.index(TEST_INSTRUCTION), result.index("<core_identity>"))
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_injects_before_markdown_core_identity(self):
+        result = self._call_get_supervisor_instructions(
+            instruction=CORE_IDENTITY_MARKDOWN_PROMPT,
+            rationale_switch=True,
+        )
+
+        self.assertIn(TEST_INSTRUCTION, result)
+        self.assertLess(result.index(TEST_INSTRUCTION), result.index("## Core Identity"))
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_skips_when_rationale_switch_disabled(self):
+        result = self._call_get_supervisor_instructions(rationale_switch=False)
+
+        self.assertNotIn(TEST_INSTRUCTION, result)
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_skips_when_turn_off_rationale(self):
+        result = self._call_get_supervisor_instructions(
+            rationale_switch=True,
+            turn_off_rationale=True,
+        )
+
+        self.assertNotIn(TEST_INSTRUCTION, result)
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION="")
+    def test_skips_when_setting_empty(self):
+        result = self._call_get_supervisor_instructions(rationale_switch=True)
+
+        self.assertNotIn(DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION, result)
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_prepends_when_marker_missing(self):
+        result = self._call_get_supervisor_instructions(
+            instruction=NO_MARKER_PROMPT,
+            rationale_switch=True,
+        )
+
+        self.assertTrue(result.startswith(f"{TEST_INSTRUCTION}\n\n# Manager"))

--- a/nexus/settings.py
+++ b/nexus/settings.py
@@ -632,6 +632,13 @@ SKILL_FILE_SIZE_LIMIT = env.int("SKILL_FILE_SIZE_LIMIT", 50)
 
 RATIONALE_IMPROVEMENT_INSTRUCTIONS = env.str("RATIONALE_IMPROVEMENT_INSTRUCTIONS", "")
 SUBSEQUENT_RATIONALE_INSTRUCTIONS = env.str("SUBSEQUENT_RATIONALE_INSTRUCTIONS", "")
+PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION = env.str(
+    "PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION",
+    default=(
+        "Before executing ANY tool or calling an agent, send the user a short feedback message "
+        "explaining what you're about to do, so they know the request is being processed."
+    ),
+)
 
 START_INLINE_AGENTS_ACK_LATE = env.bool("START_INLINE_AGENTS_ACK_LATE", False)
 ENABLE_LOGFIRE_OPENAI_AGENTS = env.bool("ENABLE_LOGFIRE_OPENAI_AGENTS", False)

--- a/router/traces_observers/rationale/channel_hint.py
+++ b/router/traces_observers/rationale/channel_hint.py
@@ -1,0 +1,30 @@
+WEBCHAT_CHANNEL_TYPES = frozenset({"WWC", "WEBCHAT", "WEB_CHAT"})
+
+
+def is_webchat_channel(contact_urn: str, channel_type: str = "") -> bool:
+    if (channel_type or "").strip().upper() in WEBCHAT_CHANNEL_TYPES:
+        return True
+    lower = (contact_urn or "").lower()
+    return lower.startswith("ext:") or "webchat" in lower
+
+
+def channel_hint_from_contact_urn(contact_urn: str, channel_type: str = "") -> str:
+    """Log label: web for webchat channels, otherwise the URN prefix."""
+    if is_webchat_channel(contact_urn, channel_type):
+        return "web"
+    if not contact_urn:
+        return "unknown"
+    prefix, _, _ = contact_urn.partition(":")
+    return prefix or "unknown"
+
+
+def supports_progressive_feedback(
+    contact_urn: str,
+    channel_type: str = "",
+    *,
+    preview: bool = False,
+    preview_websocket: bool = False,
+) -> bool:
+    if preview or preview_websocket:
+        return True
+    return is_webchat_channel(contact_urn, channel_type)

--- a/router/traces_observers/rationale/handlers.py
+++ b/router/traces_observers/rationale/handlers.py
@@ -7,6 +7,8 @@ This module extracts complex logic from RationaleObserver to reduce cyclomatic c
 import logging
 from typing import Callable, Dict, Optional
 
+from router.traces_observers.rationale.channel_hint import channel_hint_from_contact_urn
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,6 +47,15 @@ class RationaleMessageSender:
         from router.traces_observers.save_traces import save_inline_message_to_database
 
         try:
+            logger.info(
+                "[ProgressiveFeedback] Sending rationale message project_uuid=%s channel_from_urn=%s "
+                "contact_urn=%s channel_uuid=%s text_preview=%r",
+                project_uuid,
+                channel_hint_from_contact_urn(contact_urn),
+                contact_urn,
+                channel_uuid,
+                text[:120],
+            )
             send_message_callback(
                 text=text,
                 urns=[contact_urn],

--- a/router/traces_observers/rationale/observer.py
+++ b/router/traces_observers/rationale/observer.py
@@ -112,7 +112,29 @@ class RationaleObserver(EventObserver):
         **kwargs,
     ) -> None:
         """Process rationale from inline traces."""
+        from router.traces_observers.rationale.channel_hint import (
+            channel_hint_from_contact_urn,
+            supports_progressive_feedback,
+        )
+
         if not rationale_switch or turn_off_rationale:
+            return
+
+        channel_type = kwargs.get("channel_type", "")
+        if not supports_progressive_feedback(
+            contact_urn,
+            channel_type,
+            preview=preview,
+            preview_websocket=preview_websocket,
+        ):
+            logger.info(
+                "[ProgressiveFeedback] Skipped rationale processing project_uuid=%s channel_from_urn=%s "
+                "contact_urn=%s channel_type=%s reason=non_webchat",
+                project_uuid,
+                channel_hint_from_contact_urn(contact_urn),
+                contact_urn,
+                channel_type or None,
+            )
             return
 
         try:


### PR DESCRIPTION
## Progressive Feedback Orchestration Instruction

- Introduced a new `PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION` setting that instructs the supervisor to send users a short feedback message before executing any tool or calling an agent, configurable via environment variable with a sensible default.
- Updated `OpenAITeamAdapter` (`to_external`, `to_external_enhanced`, and `get_supervisor_instructions`) to accept and forward `rationale_switch` and `turn_off_rationale` flags, enabling conditional injection of the progressive feedback instruction into rendered supervisor prompts.
- Created `prompts_progressive_feedback.py` to encapsulate the logic for retrieving, evaluating, and injecting the progressive feedback instruction — including anchor-aware insertion before `<core_identity>` or `## Core Identity` markers — and added a full test suite covering injection behavior, guard conditions, and settings-driven toggling.