### PR TITLE
feat: add AgentConstant model with sync, admin, and API serialization

### DIFF
--- a/inline_agents/backends/openai/adapter.py
+++ b/inline_agents/backends/openai/adapter.py
@@ -6,6 +6,7 @@ import boto3
 import pendulum
 import sentry_sdk
 from django.conf import settings
+from django.db.models import Prefetch
 from django.template import Context as TemplateContext
 from django.template import Template
 from django.utils.text import slugify
@@ -23,11 +24,13 @@ from inline_agents.backends.openai.hooks import CollaboratorHooks, RunnerHooks, 
 from inline_agents.backends.openai.legacy_formatter_pipeline import is_legacy_pipeline_version
 from inline_agents.data_lake.event_service import DataLakeEventService
 from nexus.inline_agents.models import (
+    AgentConstant,
     AgentCredential,
     Guardrail,
     InlineAgentsConfiguration,
     IntegratedAgent,
 )
+from nexus.usecases.inline_agents.agent_constants_sync import iter_agent_constant_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -577,9 +580,16 @@ class OpenAITeamAdapter(TeamAdapter):
                 f"Searching for agent with tool '{function_name}' in project '{project_uuid}'"
                 f" - function_name: {function_name}, project_uuid: {project_uuid}"
             )
-            integrated_agents = IntegratedAgent.objects.filter(
-                project__uuid=project_uuid, is_active=True
-            ).select_related("agent")
+            integrated_agents = (
+                IntegratedAgent.objects.filter(project__uuid=project_uuid, is_active=True)
+                .select_related("agent")
+                .prefetch_related(
+                    Prefetch(
+                        "agent__agentconstant_set",
+                        queryset=AgentConstant.objects.all(),
+                    )
+                )
+            )
 
             integrated_agents_count = integrated_agents.count()
             logger.debug(
@@ -655,10 +665,7 @@ class OpenAITeamAdapter(TeamAdapter):
     @classmethod
     def _prepare_agent_constants(cls, agent, integrated_agent=None):
         """Extract constants from agent configuration."""
-        constants = {}
-        for row in agent.agentconstant_set.all():
-            if row.default_value is not None:
-                constants[row.key] = row.default_value
+        constants = iter_agent_constant_defaults(agent)
 
         if integrated_agent and integrated_agent.metadata:
             mcp_config = integrated_agent.metadata.get("mcp_config", {})

--- a/inline_agents/backends/openai/adapter.py
+++ b/inline_agents/backends/openai/adapter.py
@@ -274,9 +274,7 @@ class OpenAITeamAdapter(TeamAdapter):
         json_tools = cls._get_tools(supervisor["tools"])
         if not use_components:
             component_tool_names_to_strip = all_component_tool_names(formatter_tools_descriptions)
-            json_tools = [
-                t for t in json_tools if getattr(t, "name", None) not in component_tool_names_to_strip
-            ]
+            json_tools = [t for t in json_tools if getattr(t, "name", None) not in component_tool_names_to_strip]
 
         supervisor_tools: List[Any] = list(json_tools)
         supervisor_tools.extend(agents_as_tools)
@@ -289,12 +287,8 @@ class OpenAITeamAdapter(TeamAdapter):
             legacy_component_tool_name_set = all_component_tool_names(formatter_tools_descriptions)
             streaming_merge_tool_name_set = streaming_merge_tool_names(formatter_tools_descriptions)
             names_to_strip = legacy_component_tool_name_set | streaming_merge_tool_name_set
-            supervisor_tools = [
-                t for t in supervisor_tools if getattr(t, "name", None) not in names_to_strip
-            ]
-            supervisor_tools.extend(
-                get_supervisor_component_tools_for_streaming_merge(formatter_tools_descriptions)
-            )
+            supervisor_tools = [t for t in supervisor_tools if getattr(t, "name", None) not in names_to_strip]
+            supervisor_tools.extend(get_supervisor_component_tools_for_streaming_merge(formatter_tools_descriptions))
 
         supervisor_agent = SupervisorEntity(
             name="manager",
@@ -662,10 +656,10 @@ class OpenAITeamAdapter(TeamAdapter):
     def _prepare_agent_constants(cls, agent, integrated_agent=None):
         """Extract constants from agent configuration."""
         constants = {}
-        if hasattr(agent, "constants") and agent.constants:
-            constants = {k: v.get("value", "") if isinstance(v, dict) else v for k, v in agent.constants.items()}
+        for row in agent.agentconstant_set.all():
+            if row.default_value is not None:
+                constants[row.key] = row.default_value
 
-        # Inject mcp_config into constants
         if integrated_agent and integrated_agent.metadata:
             mcp_config = integrated_agent.metadata.get("mcp_config", {})
             if isinstance(mcp_config, dict):

--- a/nexus/inline_agents/admin.py
+++ b/nexus/inline_agents/admin.py
@@ -18,6 +18,7 @@ from nexus.inline_agents.models import (
     MCP,
     Agent,
     AgentCategory,
+    AgentConstant,
     AgentCredential,
     AgentGroup,
     AgentGroupModal,
@@ -247,6 +248,50 @@ class AgentCredentialInline(admin.TabularInline):
     view_link.short_description = "Actions"
 
 
+class AgentConstantInline(admin.TabularInline):
+    model = AgentConstant.agents.through
+    extra = 0
+    can_delete = False
+    show_change_link = False
+    verbose_name = "Constant"
+    verbose_name_plural = "Constants"
+    fields = ("constant_key", "constant_label", "constant_type", "constant_is_required", "view_link")
+    readonly_fields = fields
+
+    def constant_key(self, obj):
+        return getattr(obj.agentconstant, "key", None)
+
+    def constant_label(self, obj):
+        return getattr(obj.agentconstant, "label", None)
+
+    def constant_type(self, obj):
+        return getattr(obj.agentconstant, "type", None)
+
+    def constant_is_required(self, obj):
+        return getattr(obj.agentconstant, "is_required", None)
+
+    def view_link(self, obj):
+        if getattr(obj, "agentconstant_id", None):
+            url = reverse("admin:inline_agents_agentconstant_change", args=[obj.agentconstant_id])
+            return format_html('<a href="{}" target="_blank">View</a>', url)
+        return "-"
+
+    constant_key.short_description = "Key"
+    constant_label.short_description = "Label"
+    constant_type.short_description = "Type"
+    constant_is_required.short_description = "Required"
+    view_link.short_description = "Actions"
+
+
+@admin.register(AgentConstant)
+class AgentConstantAdmin(admin.ModelAdmin):
+    list_display = ("key", "label", "type", "project", "is_required")
+    list_filter = ("type", "is_required")
+    search_fields = ("key", "label", "project__name", "project__uuid")
+    ordering = ("project__name", "key")
+    autocomplete_fields = ["project", "agents"]
+
+
 @admin.register(Version)
 class VersionAdmin(admin.ModelAdmin):
     """Admin interface for Version model - shows skills and display_skills"""
@@ -275,7 +320,7 @@ class AgentAdmin(admin.ModelAdmin):
     search_fields = ("name", "project__name", "project__uuid", "slug", "uuid")
     ordering = ("project__name",)
     autocomplete_fields = ["project", "group", "systems", "agent_type", "category", "mcps"]
-    inlines = [VersionInline, AgentCredentialInline]
+    inlines = [VersionInline, AgentCredentialInline, AgentConstantInline]
     readonly_fields = ("mcps_list",)
 
     fieldsets = (

--- a/nexus/inline_agents/api/serializers/catalog.py
+++ b/nexus/inline_agents/api/serializers/catalog.py
@@ -16,7 +16,8 @@ from nexus.inline_agents.api.official_agents_helpers import (
     get_all_mcps_for_group,
     get_all_systems_for_group,
 )
-from nexus.inline_agents.models import MCP, Agent, AgentCredential, IntegratedAgent
+from nexus.inline_agents.models import MCP, Agent, AgentConstant, AgentCredential, IntegratedAgent
+from nexus.usecases.inline_agents.agent_constant_definitions import serialize_agent_constant_for_api
 
 
 def my_agents_list_prefetches() -> list:
@@ -26,6 +27,10 @@ def my_agents_list_prefetches() -> list:
         Prefetch(
             "agentcredential_set",
             queryset=AgentCredential.objects.order_by("key"),
+        ),
+        Prefetch(
+            "agentconstant_set",
+            queryset=AgentConstant.objects.order_by("key"),
         ),
         Prefetch(
             "mcps",
@@ -207,6 +212,25 @@ def _agent_credentials_payload(agent: Agent) -> list[dict[str, Any]]:
     return rows
 
 
+def _iter_agent_constants(agent: Agent) -> list[AgentConstant]:
+    cache = getattr(agent, "_prefetched_objects_cache", None)
+    if isinstance(cache, dict) and "agentconstant_set" in cache:
+        return sorted(cache["agentconstant_set"], key=lambda row: row.key or "")
+    return list(agent.agentconstant_set.all().order_by("key"))
+
+
+def _agent_constants_payload(agent: Agent) -> list[dict[str, Any]]:
+    seen_keys: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    for constant in _iter_agent_constants(agent):
+        key = constant.key
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        rows.append(serialize_agent_constant_for_api(constant))
+    return rows
+
+
 def _merge_agent_credentials_into_mcp(mcp_data: dict[str, Any], agent_credentials: list[dict[str, Any]]) -> None:
     """Fill ``mcp_data['credentials']`` from agent credentials when MCP templates are missing or partial."""
     if not agent_credentials:
@@ -220,27 +244,45 @@ def _merge_agent_credentials_into_mcp(mcp_data: dict[str, Any], agent_credential
             mcp_data["credentials"].append(credential)
 
 
-def _synthetic_mcp_for_agent_credentials(agent: Agent, credentials: list[dict[str, Any]]) -> dict[str, Any]:
-    """Carrier row for ``mcps[].credentials`` when the agent has no linked MCP (not a DB MCP)."""
+def _merge_agent_constants_into_mcp(mcp_data: dict[str, Any], agent_constants: list[dict[str, Any]]) -> None:
+    if not agent_constants:
+        return
+    if not mcp_data.get("config"):
+        mcp_data["config"] = list(agent_constants)
+        return
+    existing_names = {item["name"] for item in mcp_data["config"]}
+    for constant in agent_constants:
+        if constant["name"] not in existing_names:
+            mcp_data["config"].append(constant)
+
+
+def _synthetic_mcp_for_standalone_agent(
+    agent: Agent,
+    credentials: list[dict[str, Any]],
+    constants: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Carrier row for standalone agents without a linked MCP (not a DB MCP)."""
     description = (agent.collaboration_instructions or "").strip() or None
     return {
         "name": None,
         "description": {"en": description, "pt": None, "es": None},
         "system": None,
-        "config": [],
+        "config": constants,
         "credentials": credentials,
     }
 
 
 def _mcps_for_standalone_agent(agent: Agent) -> list[dict[str, Any]]:
     agent_credentials = _agent_credentials_payload(agent)
+    agent_constants = _agent_constants_payload(agent)
     serialized = [_serialize_mcp(m) for m in _iter_active_agent_mcps(agent)]
     if serialized:
         for mcp_data in serialized:
             _merge_agent_credentials_into_mcp(mcp_data, agent_credentials)
+            _merge_agent_constants_into_mcp(mcp_data, agent_constants)
         return _sort_mcps(serialized)
-    if agent_credentials:
-        return [_synthetic_mcp_for_agent_credentials(agent, agent_credentials)]
+    if agent_credentials or agent_constants:
+        return [_synthetic_mcp_for_standalone_agent(agent, agent_credentials, agent_constants)]
     return []
 
 

--- a/nexus/inline_agents/migrations/0030_agentconstant.py
+++ b/nexus/inline_agents/migrations/0030_agentconstant.py
@@ -1,6 +1,42 @@
 from django.db import migrations, models
 
 
+def backfill_agent_constants_from_mcp_options(apps, schema_editor):
+    """Copy MCP config option schemas onto agents that lack AgentConstant rows.
+
+    The legacy ``Agent.constants`` JSONField was removed in migration 0023 before
+    this table existed, so that data cannot be recovered here. Agents that only
+    synced constants through linked MCPs still have schemas in ``MCPConfigOption``.
+    Standalone agents without a re-push must be updated from weni-cli YAML.
+    """
+    Agent = apps.get_model("inline_agents", "Agent")
+    AgentConstant = apps.get_model("inline_agents", "AgentConstant")
+    MCPConfigOption = apps.get_model("inline_agents", "MCPConfigOption")
+
+    for agent in Agent.objects.iterator():
+        if AgentConstant.objects.filter(agents=agent).exists():
+            continue
+
+        mcp_ids = list(agent.mcps.values_list("pk", flat=True))
+        if not mcp_ids:
+            continue
+
+        for option in MCPConfigOption.objects.filter(mcp_id__in=mcp_ids).order_by("order", "name"):
+            row, _created = AgentConstant.objects.get_or_create(
+                project_id=agent.project_id,
+                key=option.name,
+                defaults={
+                    "label": option.label,
+                    "type": option.type,
+                    "options": option.options,
+                    "default_value": option.default_value,
+                    "is_required": option.is_required,
+                    "definition": {},
+                },
+            )
+            row.agents.add(agent)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -47,5 +83,9 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("project", "key")},
             },
+        ),
+        migrations.RunPython(
+            backfill_agent_constants_from_mcp_options,
+            migrations.RunPython.noop,
         ),
     ]

--- a/nexus/inline_agents/migrations/0030_agentconstant.py
+++ b/nexus/inline_agents/migrations/0030_agentconstant.py
@@ -1,0 +1,51 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inline_agents", "0029_modelprovider_projectmodelprovider"),
+        ("projects", "0027_alter_project_inline_agent_switch_default"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AgentConstant",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("key", models.CharField(max_length=255)),
+                ("label", models.CharField(max_length=255)),
+                (
+                    "type",
+                    models.CharField(
+                        choices=[
+                            ("TEXT", "Text"),
+                            ("NUMBER", "Number"),
+                            ("CHECKBOX", "Checkbox"),
+                            ("SELECT", "Select"),
+                            ("RADIO", "Radio"),
+                            ("SWITCH", "Switch"),
+                        ],
+                        default="TEXT",
+                        max_length=20,
+                    ),
+                ),
+                ("options", models.JSONField(blank=True, default=list)),
+                ("default_value", models.JSONField(blank=True, default=None, null=True)),
+                ("is_required", models.BooleanField(default=False)),
+                ("definition", models.JSONField(blank=True, default=dict)),
+                ("agents", models.ManyToManyField(to="inline_agents.agent")),
+                (
+                    "project",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="inline_constants",
+                        to="projects.project",
+                    ),
+                ),
+            ],
+            options={
+                "unique_together": {("project", "key")},
+            },
+        ),
+    ]

--- a/nexus/inline_agents/migrations/0030_agentconstant.py
+++ b/nexus/inline_agents/migrations/0030_agentconstant.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                 (
                     "project",
                     models.ForeignKey(
-                        on_delete=models.deletion.CASCADE,
+                        on_delete=models.CASCADE,
                         related_name="inline_constants",
                         to="projects.project",
                     ),

--- a/nexus/inline_agents/models.py
+++ b/nexus/inline_agents/models.py
@@ -172,6 +172,48 @@ class AgentCredential(models.Model):
         return self.value
 
 
+class AgentConstant(models.Model):
+    """Agent-level constant definitions (schema), mirroring AgentCredential for config options."""
+
+    TEXT = "TEXT"
+    NUMBER = "NUMBER"
+    CHECKBOX = "CHECKBOX"
+    SELECT = "SELECT"
+    RADIO = "RADIO"
+    SWITCH = "SWITCH"
+
+    TYPE_CHOICES = (
+        (TEXT, "Text"),
+        (NUMBER, "Number"),
+        (CHECKBOX, "Checkbox"),
+        (SELECT, "Select"),
+        (RADIO, "Radio"),
+        (SWITCH, "Switch"),
+    )
+
+    project = models.ForeignKey(Project, on_delete=models.CASCADE, related_name="inline_constants")
+    key = models.CharField(max_length=255)
+    label = models.CharField(max_length=255)
+    type = models.CharField(max_length=20, choices=TYPE_CHOICES, default=TEXT)
+    options = models.JSONField(default=list, blank=True)
+    default_value = models.JSONField(default=None, null=True, blank=True)
+    is_required = models.BooleanField(default=False)
+    definition = models.JSONField(default=dict, blank=True)
+    agents = models.ManyToManyField(Agent)
+
+    class Meta:
+        unique_together = ("project", "key")
+
+    def __str__(self):
+        return self.label
+
+    def save(self, *args, **kwargs):
+        if self.type in (self.SWITCH, self.NUMBER, self.TEXT, self.CHECKBOX):
+            if not isinstance(self.options, list):
+                self.options = []
+        super().save(*args, **kwargs)
+
+
 class ContactField(models.Model):
     agent = models.ForeignKey(Agent, on_delete=models.CASCADE, related_name="inline_contact_fields")
     project = models.ForeignKey(Project, on_delete=models.CASCADE, related_name="inline_contact_fields")

--- a/nexus/usecases/inline_agents/agent_constant_definitions.py
+++ b/nexus/usecases/inline_agents/agent_constant_definitions.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.inline_agents.models import AgentConstant
+
+_TYPE_MAP = {
+    "text": AgentConstant.TEXT,
+    "number": AgentConstant.NUMBER,
+    "checkbox": AgentConstant.CHECKBOX,
+    "select": AgentConstant.SELECT,
+    "radio": AgentConstant.RADIO,
+    "switch": AgentConstant.SWITCH,
+}
+
+
+def constant_type_from_yaml(raw: Any) -> str:
+    if not isinstance(raw, str):
+        return AgentConstant.TEXT
+    return _TYPE_MAP.get(raw.strip().lower(), AgentConstant.TEXT)
+
+
+def normalize_constant_options(constant_def: dict[str, Any], field_type: str) -> list[dict[str, Any]]:
+    if field_type not in (AgentConstant.RADIO, AgentConstant.SELECT):
+        return []
+    options = constant_def.get("options")
+    if not isinstance(options, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for item in options:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") if item.get("name") is not None else item.get("label")
+        val = item.get("value")
+        if name is not None and val is not None:
+            normalized.append({"name": str(name), "value": val})
+    return normalized
+
+
+def fields_from_yaml_constant(key: str, constant_def: dict[str, Any]) -> dict[str, Any]:
+    field_type = constant_type_from_yaml(constant_def.get("type"))
+    return {
+        "key": key,
+        "label": str(constant_def.get("label", key))[:255],
+        "type": field_type,
+        "options": normalize_constant_options(constant_def, field_type),
+        "default_value": constant_def.get("default"),
+        "is_required": bool(constant_def.get("required", False)),
+        "definition": constant_def,
+    }
+
+
+def serialize_agent_constant_for_api(constant: AgentConstant) -> dict[str, Any]:
+    options = constant.options
+    if constant.type in (AgentConstant.SWITCH, AgentConstant.NUMBER, AgentConstant.TEXT, AgentConstant.CHECKBOX):
+        if not isinstance(options, list):
+            options = []
+    payload: dict[str, Any] = {
+        "name": constant.key,
+        "label": constant.label,
+        "type": constant.type,
+        "options": options,
+        "is_required": constant.is_required,
+    }
+    if constant.default_value is not None:
+        payload["default_value"] = constant.default_value
+    return payload

--- a/nexus/usecases/inline_agents/agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/agent_constants_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from django.db import transaction
+from django.db.models import Count, Q
 
 from nexus.inline_agents.models import Agent, AgentConstant
 from nexus.projects.models import Project
@@ -29,8 +30,37 @@ def _apply_constant_fields(row: AgentConstant, fields: dict[str, Any]) -> None:
 
 
 def _link_agent_to_constant(agent: Agent, row: AgentConstant) -> None:
-    if not row.agents.filter(pk=agent.pk).exists():
+    agent_ids = {linked.pk for linked in row.agents.all()}
+    if agent.pk not in agent_ids:
         row.agents.add(agent)
+
+
+def _locked_constants_for_sync(
+    project: Project,
+    agent: Agent,
+    payload_keys: set[str],
+) -> dict[str, AgentConstant]:
+    lock_filter = Q(agents=agent)
+    if payload_keys:
+        lock_filter |= Q(key__in=payload_keys)
+
+    rows = (
+        AgentConstant.objects.filter(project=project)
+        .filter(lock_filter)
+        .annotate(agent_count=Count("agents", distinct=True))
+        .prefetch_related("agents")
+        .order_by("key")
+        .distinct()
+        .select_for_update()
+    )
+    return {row.key: row for row in rows}
+
+
+def _linked_constants_for_agent(
+    locked_by_key: dict[str, AgentConstant],
+    agent: Agent,
+) -> dict[str, AgentConstant]:
+    return {key: row for key, row in locked_by_key.items() if any(linked.pk == agent.pk for linked in row.agents.all())}
 
 
 @transaction.atomic
@@ -42,17 +72,17 @@ def sync_agent_constants_from_payload(
     prune_missing: bool = False,
 ) -> None:
     """Create or update AgentConstant rows from a weni-cli push payload."""
-    linked_to_agent = {
-        row.key: row for row in AgentConstant.objects.filter(project=project, agents=agent).select_for_update()
-    }
-    payload_keys: set[str] = set()
-
+    parsed: dict[str, dict[str, Any]] = {}
     for key, constant_def in constants.items():
-        if not isinstance(constant_def, dict):
-            continue
-        payload_keys.add(key)
-        fields = fields_from_yaml_constant(key, constant_def)
-        row = linked_to_agent.get(key) or AgentConstant.objects.filter(project=project, key=key).first()
+        if isinstance(constant_def, dict):
+            parsed[key] = fields_from_yaml_constant(key, constant_def)
+
+    payload_keys = set(parsed.keys())
+    locked_by_key = _locked_constants_for_sync(project, agent, payload_keys)
+    linked_to_agent = _linked_constants_for_agent(locked_by_key, agent)
+
+    for key, fields in parsed.items():
+        row = locked_by_key.get(key)
         if row:
             _apply_constant_fields(row, fields)
             row.save()
@@ -71,6 +101,7 @@ def sync_agent_constants_from_payload(
             definition=fields["definition"],
         )
         row.agents.add(agent)
+        locked_by_key[key] = row
         linked_to_agent[key] = row
 
     if not prune_missing:
@@ -79,7 +110,7 @@ def sync_agent_constants_from_payload(
     for key, row in linked_to_agent.items():
         if key in payload_keys:
             continue
-        if row.agents.count() == 1:
+        if row.agent_count == 1:
             row.delete()
         else:
             row.agents.remove(agent)

--- a/nexus/usecases/inline_agents/agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/agent_constants_sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from django.db import transaction
-from django.db.models import Count, Q
+from django.db.models import Count
 
 from nexus.inline_agents.models import Agent, AgentConstant
 from nexus.projects.models import Project
@@ -40,12 +40,20 @@ def _locked_constants_for_sync(
     agent: Agent,
     payload_keys: set[str],
 ) -> dict[str, AgentConstant]:
-    lock_filter = Q(agents=agent)
+    # Lock rows by primary key only. Filtering M2M (agents=agent) in the same
+    # select_for_update() query produces an outer join that PostgreSQL rejects.
+    pk_candidates: set[int] = set(
+        AgentConstant.objects.filter(project=project, agents=agent).values_list("pk", flat=True)
+    )
     if payload_keys:
-        lock_filter |= Q(key__in=payload_keys)
+        pk_candidates.update(
+            AgentConstant.objects.filter(project=project, key__in=payload_keys).values_list("pk", flat=True)
+        )
 
-    # PostgreSQL rejects FOR UPDATE with GROUP BY from Count() annotations.
-    rows = AgentConstant.objects.filter(project=project).filter(lock_filter).order_by("pk").select_for_update()
+    if not pk_candidates:
+        return {}
+
+    rows = AgentConstant.objects.filter(project=project, pk__in=pk_candidates).order_by("pk").select_for_update()
     locked_by_key: dict[str, AgentConstant] = {}
     for row in rows:
         locked_by_key.setdefault(row.key, row)

--- a/nexus/usecases/inline_agents/agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/agent_constants_sync.py
@@ -50,10 +50,12 @@ def _locked_constants_for_sync(
         .annotate(agent_count=Count("agents", distinct=True))
         .prefetch_related("agents")
         .order_by("key")
-        .distinct()
         .select_for_update()
     )
-    return {row.key: row for row in rows}
+    locked_by_key: dict[str, AgentConstant] = {}
+    for row in rows:
+        locked_by_key.setdefault(row.key, row)
+    return locked_by_key
 
 
 def _linked_constants_for_agent(

--- a/nexus/usecases/inline_agents/agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/agent_constants_sync.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import transaction
+
+from nexus.inline_agents.models import Agent, AgentConstant
+from nexus.projects.models import Project
+from nexus.usecases.inline_agents.agent_constant_definitions import fields_from_yaml_constant
+
+
+def iter_agent_constant_defaults(agent: Agent) -> dict[str, Any]:
+    """Default constant values for an agent, using prefetched rows when available."""
+    cache = getattr(agent, "_prefetched_objects_cache", None)
+    if isinstance(cache, dict) and "agentconstant_set" in cache:
+        rows = cache["agentconstant_set"]
+    else:
+        rows = agent.agentconstant_set.all()
+    return {row.key: row.default_value for row in rows if row.default_value is not None}
+
+
+def _apply_constant_fields(row: AgentConstant, fields: dict[str, Any]) -> None:
+    row.label = fields["label"]
+    row.type = fields["type"]
+    row.options = fields["options"]
+    row.default_value = fields["default_value"]
+    row.is_required = fields["is_required"]
+    row.definition = fields["definition"]
+
+
+def _link_agent_to_constant(agent: Agent, row: AgentConstant) -> None:
+    if not row.agents.filter(pk=agent.pk).exists():
+        row.agents.add(agent)
+
+
+@transaction.atomic
+def sync_agent_constants_from_payload(
+    agent: Agent,
+    project: Project,
+    constants: dict[str, Any],
+    *,
+    prune_missing: bool = False,
+) -> None:
+    """Create or update AgentConstant rows from a weni-cli push payload."""
+    linked_to_agent = {
+        row.key: row for row in AgentConstant.objects.filter(project=project, agents=agent).select_for_update()
+    }
+    payload_keys: set[str] = set()
+
+    for key, constant_def in constants.items():
+        if not isinstance(constant_def, dict):
+            continue
+        payload_keys.add(key)
+        fields = fields_from_yaml_constant(key, constant_def)
+        row = linked_to_agent.get(key) or AgentConstant.objects.filter(project=project, key=key).first()
+        if row:
+            _apply_constant_fields(row, fields)
+            row.save()
+            _link_agent_to_constant(agent, row)
+            linked_to_agent[key] = row
+            continue
+
+        row = AgentConstant.objects.create(
+            project=project,
+            key=fields["key"],
+            label=fields["label"],
+            type=fields["type"],
+            options=fields["options"],
+            default_value=fields["default_value"],
+            is_required=fields["is_required"],
+            definition=fields["definition"],
+        )
+        row.agents.add(agent)
+        linked_to_agent[key] = row
+
+    if not prune_missing:
+        return
+
+    for key, row in linked_to_agent.items():
+        if key in payload_keys:
+            continue
+        if row.agents.count() == 1:
+            row.delete()
+        else:
+            row.agents.remove(agent)

--- a/nexus/usecases/inline_agents/agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/agent_constants_sync.py
@@ -44,18 +44,22 @@ def _locked_constants_for_sync(
     if payload_keys:
         lock_filter |= Q(key__in=payload_keys)
 
-    rows = (
-        AgentConstant.objects.filter(project=project)
-        .filter(lock_filter)
-        .annotate(agent_count=Count("agents", distinct=True))
-        .prefetch_related("agents")
-        .order_by("key")
-        .select_for_update()
-    )
+    # PostgreSQL rejects FOR UPDATE with GROUP BY from Count() annotations.
+    rows = AgentConstant.objects.filter(project=project).filter(lock_filter).order_by("pk").select_for_update()
     locked_by_key: dict[str, AgentConstant] = {}
     for row in rows:
         locked_by_key.setdefault(row.key, row)
-    return locked_by_key
+
+    if not locked_by_key:
+        return locked_by_key
+
+    enriched_by_pk = {
+        row.pk: row
+        for row in AgentConstant.objects.filter(pk__in=[row.pk for row in locked_by_key.values()])
+        .prefetch_related("agents")
+        .annotate(agent_count=Count("agents", distinct=True))
+    }
+    return {key: enriched_by_pk[row.pk] for key, row in locked_by_key.items()}
 
 
 def _linked_constants_for_agent(
@@ -112,7 +116,8 @@ def sync_agent_constants_from_payload(
     for key, row in linked_to_agent.items():
         if key in payload_keys:
             continue
-        if row.agent_count == 1:
+        agent_count = getattr(row, "agent_count", row.agents.count())
+        if agent_count == 1:
             row.delete()
         else:
             row.agents.remove(agent)

--- a/nexus/usecases/inline_agents/create.py
+++ b/nexus/usecases/inline_agents/create.py
@@ -8,6 +8,7 @@ from nexus.agents.encryption import encrypt_value
 from nexus.inline_agents.models import (
     MCP,
     Agent,
+    AgentConstant,
     AgentCredential,
     AgentGroup,
     AgentSystem,
@@ -15,6 +16,7 @@ from nexus.inline_agents.models import (
 )
 from nexus.intelligences.models import Conversation
 from nexus.projects.models import Project
+from nexus.usecases.inline_agents.agent_constant_definitions import fields_from_yaml_constant
 from nexus.usecases.inline_agents.bedrock import BedrockClient
 from nexus.usecases.inline_agents.instructions import InstructionsUseCase
 from nexus.usecases.inline_agents.mcp_definition_sync import sync_mcp_templates_from_agent_payload
@@ -43,6 +45,7 @@ class CreateAgentUseCase(ToolsUseCase, InstructionsUseCase):
         )
         self.handle_tools(agent_obj, project, agent["tools"], files, str(project.uuid))
         self.create_credentials(agent_obj, project, agent.get("credentials", {}))
+        self.create_constants(agent_obj, project, agent.get("constants", {}))
 
         if agent.get("group"):
             group = AgentGroup.objects.filter(slug=agent.get("group")).first()
@@ -102,14 +105,38 @@ class CreateAgentUseCase(ToolsUseCase, InstructionsUseCase):
         logger.info(f"Created agent - agent_key: {agent_key}")
         return agent_obj
 
-    def _process_constants(self, constants: Dict) -> Dict | None:
-        """Process constants from weni-cli YAML format to stored format"""
+    def create_constants(self, agent: Agent, project: Project, constants: Dict):
         if not constants:
-            return None
-        processed = {}
+            return
+
         for key, constant_def in constants.items():
-            processed[key] = {"value": constant_def.get("default", ""), "definition": constant_def}
-        return processed
+            if not isinstance(constant_def, dict):
+                continue
+            logger.info(f"Creating constant - key: {key}")
+            fields = fields_from_yaml_constant(key, constant_def)
+            existing = AgentConstant.objects.filter(project=project, key=key).first()
+            if existing:
+                existing.label = fields["label"]
+                existing.type = fields["type"]
+                existing.options = fields["options"]
+                existing.default_value = fields["default_value"]
+                existing.is_required = fields["is_required"]
+                existing.definition = fields["definition"]
+                existing.save()
+                if agent not in existing.agents.all():
+                    existing.agents.add(agent)
+            else:
+                new_constant = AgentConstant.objects.create(
+                    project=project,
+                    key=fields["key"],
+                    label=fields["label"],
+                    type=fields["type"],
+                    options=fields["options"],
+                    default_value=fields["default_value"],
+                    is_required=fields["is_required"],
+                    definition=fields["definition"],
+                )
+                new_constant.agents.add(agent)
 
     def create_credentials(self, agent: Agent, project: Project, credentials: Dict):
         created_credentials = []

--- a/nexus/usecases/inline_agents/create.py
+++ b/nexus/usecases/inline_agents/create.py
@@ -8,7 +8,6 @@ from nexus.agents.encryption import encrypt_value
 from nexus.inline_agents.models import (
     MCP,
     Agent,
-    AgentConstant,
     AgentCredential,
     AgentGroup,
     AgentSystem,
@@ -16,7 +15,7 @@ from nexus.inline_agents.models import (
 )
 from nexus.intelligences.models import Conversation
 from nexus.projects.models import Project
-from nexus.usecases.inline_agents.agent_constant_definitions import fields_from_yaml_constant
+from nexus.usecases.inline_agents.agent_constants_sync import sync_agent_constants_from_payload
 from nexus.usecases.inline_agents.bedrock import BedrockClient
 from nexus.usecases.inline_agents.instructions import InstructionsUseCase
 from nexus.usecases.inline_agents.mcp_definition_sync import sync_mcp_templates_from_agent_payload
@@ -108,35 +107,7 @@ class CreateAgentUseCase(ToolsUseCase, InstructionsUseCase):
     def create_constants(self, agent: Agent, project: Project, constants: Dict):
         if not constants:
             return
-
-        for key, constant_def in constants.items():
-            if not isinstance(constant_def, dict):
-                continue
-            logger.info(f"Creating constant - key: {key}")
-            fields = fields_from_yaml_constant(key, constant_def)
-            existing = AgentConstant.objects.filter(project=project, key=key).first()
-            if existing:
-                existing.label = fields["label"]
-                existing.type = fields["type"]
-                existing.options = fields["options"]
-                existing.default_value = fields["default_value"]
-                existing.is_required = fields["is_required"]
-                existing.definition = fields["definition"]
-                existing.save()
-                if agent not in existing.agents.all():
-                    existing.agents.add(agent)
-            else:
-                new_constant = AgentConstant.objects.create(
-                    project=project,
-                    key=fields["key"],
-                    label=fields["label"],
-                    type=fields["type"],
-                    options=fields["options"],
-                    default_value=fields["default_value"],
-                    is_required=fields["is_required"],
-                    definition=fields["definition"],
-                )
-                new_constant.agents.add(agent)
+        sync_agent_constants_from_payload(agent, project, constants)
 
     def create_credentials(self, agent: Agent, project: Project, credentials: Dict):
         created_credentials = []

--- a/nexus/usecases/inline_agents/tests/test_agent_constants.py
+++ b/nexus/usecases/inline_agents/tests/test_agent_constants.py
@@ -1,0 +1,98 @@
+from django.test import TestCase
+
+from nexus.inline_agents.api.serializers.catalog import _mcps_for_standalone_agent
+from nexus.inline_agents.models import Agent, AgentConstant
+from nexus.usecases.inline_agents.create import CreateAgentUseCase
+from nexus.usecases.inline_agents.update import UpdateAgentUseCase
+from nexus.usecases.projects.tests.project_factory import ProjectFactory
+
+
+class TestAgentConstantPush(TestCase):
+    def setUp(self):
+        self.project = ProjectFactory(name="Agent Constants", brain_on=True)
+        self.create_usecase = CreateAgentUseCase()
+        self.update_usecase = UpdateAgentUseCase()
+        self.payload = {
+            "name": "Product Concierge Agent",
+            "description": "Helps customers discover products from the store catalog.",
+            "instructions": ["You help customers find products in the store catalog."],
+            "guardrails": ["Do not discuss politics, religion or any other sensitive topic."],
+            "credentials": {
+                "BASE_URL": {
+                    "label": "VTEX Account",
+                    "placeholder": "your-store",
+                    "is_confidential": False,
+                }
+            },
+            "constants": {
+                "DISPLAY_MODE": {
+                    "label": "Send Whatsapp Catalog",
+                    "type": "radio",
+                    "options": [{"label": "Enabled", "value": "True"}, {"label": "Disabled", "value": "False"}],
+                    "default": "False",
+                    "required": True,
+                },
+                "MAX_CATALOGS": {
+                    "label": "Maximum Catalogs to Send",
+                    "type": "text",
+                    "max_length": 2,
+                    "required": False,
+                    "default": "3",
+                },
+            },
+            "tools": [],
+        }
+
+    def test_create_agent_persists_agent_constants_without_mcp(self):
+        agent = self.create_usecase.create_agent(
+            "product_concierge_agent_platform_test",
+            self.payload,
+            self.project,
+            {},
+        )
+
+        self.assertEqual(agent.agentconstant_set.count(), 2)
+        display_mode = AgentConstant.objects.get(project=self.project, key="DISPLAY_MODE")
+        self.assertEqual(display_mode.type, "RADIO")
+        self.assertEqual(display_mode.default_value, "False")
+        self.assertTrue(display_mode.is_required)
+        self.assertEqual(agent.mcps.count(), 0)
+
+    def test_standalone_agent_api_payload_includes_constant_schema(self):
+        agent = self.create_usecase.create_agent("cep_agent_constants", self.payload, self.project, {})
+
+        mcps = _mcps_for_standalone_agent(agent)
+        self.assertEqual(len(mcps), 1)
+        self.assertIsNone(mcps[0]["name"])
+        self.assertEqual(len(mcps[0]["config"]), 2)
+        config_names = {item["name"] for item in mcps[0]["config"]}
+        self.assertEqual(config_names, {"DISPLAY_MODE", "MAX_CATALOGS"})
+        self.assertEqual(len(mcps[0]["credentials"]), 1)
+
+    def test_update_agent_syncs_new_constant_definitions(self):
+        agent = Agent.objects.create(
+            name=self.payload["name"],
+            slug="update_constants_agent",
+            collaboration_instructions=self.payload["description"],
+            project=self.project,
+            instruction="x",
+            foundation_model="model:version",
+        )
+        self.create_usecase.create_constants(agent, self.project, self.payload["constants"])
+
+        updated_payload = {
+            **self.payload,
+            "constants": {
+                "MAX_RESULTS": {
+                    "label": "Maximum Results",
+                    "type": "text",
+                    "max_length": 2,
+                    "required": False,
+                    "default": "5",
+                }
+            },
+        }
+        self.update_usecase.update_agent(agent, updated_payload, self.project, {})
+
+        self.assertFalse(AgentConstant.objects.filter(project=self.project, key="DISPLAY_MODE", agents=agent).exists())
+        self.assertTrue(AgentConstant.objects.filter(project=self.project, key="MAX_RESULTS", agents=agent).exists())

--- a/nexus/usecases/inline_agents/tests/test_agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/tests/test_agent_constants_sync.py
@@ -52,3 +52,17 @@ class TestSyncAgentConstantsFromPayload(TestCase):
         sync_agent_constants_from_payload(self.agent_a, self.project, {}, prune_missing=True)
 
         self.assertFalse(AgentConstant.objects.filter(project=self.project, key="DISPLAY_MODE").exists())
+
+    def test_shared_constant_update_uses_locked_project_row(self):
+        sync_agent_constants_from_payload(self.agent_a, self.project, {"DISPLAY_MODE": DISPLAY_MODE})
+        sync_agent_constants_from_payload(self.agent_b, self.project, {"DISPLAY_MODE": DISPLAY_MODE})
+
+        updated = {
+            **DISPLAY_MODE,
+            "label": "Updated catalog mode",
+        }
+        sync_agent_constants_from_payload(self.agent_a, self.project, {"DISPLAY_MODE": updated})
+
+        row = AgentConstant.objects.get(project=self.project, key="DISPLAY_MODE")
+        self.assertEqual(row.label, "Updated catalog mode")
+        self.assertEqual(row.agents.count(), 2)

--- a/nexus/usecases/inline_agents/tests/test_agent_constants_sync.py
+++ b/nexus/usecases/inline_agents/tests/test_agent_constants_sync.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+
+from nexus.inline_agents.models import Agent, AgentConstant
+from nexus.usecases.inline_agents.agent_constants_sync import sync_agent_constants_from_payload
+from nexus.usecases.projects.tests.project_factory import ProjectFactory
+
+DISPLAY_MODE = {
+    "label": "Send Whatsapp Catalog",
+    "type": "radio",
+    "options": [{"label": "Enabled", "value": "True"}, {"label": "Disabled", "value": "False"}],
+    "default": "False",
+    "required": True,
+}
+
+
+class TestSyncAgentConstantsFromPayload(TestCase):
+    def setUp(self):
+        self.project = ProjectFactory(name="Sync Constants", brain_on=True)
+        self.agent_a = Agent.objects.create(
+            name="Agent A",
+            slug="agent-a-constants",
+            instruction="x",
+            collaboration_instructions="y",
+            project=self.project,
+            foundation_model="model:version",
+        )
+        self.agent_b = Agent.objects.create(
+            name="Agent B",
+            slug="agent-b-constants",
+            instruction="x",
+            collaboration_instructions="y",
+            project=self.project,
+            foundation_model="model:version",
+        )
+
+    def test_removing_constant_from_payload_only_unlinks_current_agent(self):
+        shared_payload = {"DISPLAY_MODE": DISPLAY_MODE}
+        sync_agent_constants_from_payload(self.agent_a, self.project, shared_payload)
+        sync_agent_constants_from_payload(self.agent_b, self.project, shared_payload)
+
+        row = AgentConstant.objects.get(project=self.project, key="DISPLAY_MODE")
+        self.assertEqual(row.agents.count(), 2)
+
+        sync_agent_constants_from_payload(self.agent_a, self.project, {}, prune_missing=True)
+
+        row.refresh_from_db()
+        self.assertTrue(row.agents.filter(pk=self.agent_b.pk).exists())
+        self.assertFalse(row.agents.filter(pk=self.agent_a.pk).exists())
+
+    def test_removing_last_linked_agent_deletes_constant_row(self):
+        sync_agent_constants_from_payload(self.agent_a, self.project, {"DISPLAY_MODE": DISPLAY_MODE})
+        sync_agent_constants_from_payload(self.agent_a, self.project, {}, prune_missing=True)
+
+        self.assertFalse(AgentConstant.objects.filter(project=self.project, key="DISPLAY_MODE").exists())

--- a/nexus/usecases/inline_agents/update.py
+++ b/nexus/usecases/inline_agents/update.py
@@ -6,6 +6,7 @@ from nexus.events import notify_async
 from nexus.inline_agents.models import (
     MCP,
     Agent,
+    AgentConstant,
     AgentCredential,
     AgentGroup,
     InlineAgentMessage,
@@ -13,6 +14,7 @@ from nexus.inline_agents.models import (
 )
 from nexus.intelligences.models import Conversation
 from nexus.projects.models import Project
+from nexus.usecases.inline_agents.agent_constant_definitions import fields_from_yaml_constant
 from nexus.usecases.inline_agents.bedrock import BedrockClient
 from nexus.usecases.inline_agents.instructions import InstructionsUseCase
 from nexus.usecases.inline_agents.mcp_definition_sync import sync_mcp_templates_from_agent_payload
@@ -55,6 +57,7 @@ class UpdateAgentUseCase(ToolsUseCase, InstructionsUseCase):
 
         self.handle_tools(agent_obj, project, agent_data["tools"], files, str(project.uuid))
         self.update_credentials(agent_obj, project, agent_data.get("credentials", {}))
+        self.update_constants(agent_obj, project, agent_data.get("constants", {}))
 
         old_group = agent_obj.group
 
@@ -83,7 +86,7 @@ class UpdateAgentUseCase(ToolsUseCase, InstructionsUseCase):
                 elif isinstance(mcp_val, str) and mcp_val:
                     mcps_data = [mcp_val]
 
-            agent_obj.mcps.clear()  # Clear existing to handle removals/updates
+            agent_obj.mcps.clear()
 
             for mcp_item in mcps_data:
                 if isinstance(mcp_item, str):
@@ -122,6 +125,54 @@ class UpdateAgentUseCase(ToolsUseCase, InstructionsUseCase):
         invalidate_team_cache_for_agent_integration_projects(agent_obj)
 
         return agent_data
+
+    def update_constants(self, agent: Agent, project: Project, constants: Dict):
+        if not constants:
+            return
+
+        existing_constants = {row.key: row for row in AgentConstant.objects.filter(project=project)}
+
+        for key, constant_def in constants.items():
+            if not isinstance(constant_def, dict):
+                continue
+            fields = fields_from_yaml_constant(key, constant_def)
+            if key in existing_constants:
+                logger.info(f"Updating constant - key: {key}")
+                row = existing_constants[key]
+                row.label = fields["label"]
+                row.type = fields["type"]
+                row.options = fields["options"]
+                row.default_value = fields["default_value"]
+                row.is_required = fields["is_required"]
+                row.definition = fields["definition"]
+                row.save()
+                if agent not in row.agents.all():
+                    row.agents.add(agent)
+                del existing_constants[key]
+            else:
+                logger.info(f"Creating constant - key: {key}")
+                row = AgentConstant.objects.create(
+                    project=project,
+                    key=fields["key"],
+                    label=fields["label"],
+                    type=fields["type"],
+                    options=fields["options"],
+                    default_value=fields["default_value"],
+                    is_required=fields["is_required"],
+                    definition=fields["definition"],
+                )
+                row.agents.add(agent)
+
+        for row in existing_constants.values():
+            linked_agents = list(row.agents.all())
+            if not linked_agents:
+                logger.info(f"Deleting empty constant - key: {row.key}, project_uuid: {str(project.uuid)}")
+                row.delete()
+            elif len(linked_agents) == 1 and agent in linked_agents:
+                logger.info(f"Deleting constant - key: {row.key}, project_uuid: {str(project.uuid)}")
+                row.delete()
+            elif agent in linked_agents:
+                row.agents.remove(agent)
 
     def update_credentials(self, agent: Agent, project: Project, credentials: Dict):
         if not credentials:

--- a/nexus/usecases/inline_agents/update.py
+++ b/nexus/usecases/inline_agents/update.py
@@ -6,7 +6,6 @@ from nexus.events import notify_async
 from nexus.inline_agents.models import (
     MCP,
     Agent,
-    AgentConstant,
     AgentCredential,
     AgentGroup,
     InlineAgentMessage,
@@ -14,7 +13,7 @@ from nexus.inline_agents.models import (
 )
 from nexus.intelligences.models import Conversation
 from nexus.projects.models import Project
-from nexus.usecases.inline_agents.agent_constant_definitions import fields_from_yaml_constant
+from nexus.usecases.inline_agents.agent_constants_sync import sync_agent_constants_from_payload
 from nexus.usecases.inline_agents.bedrock import BedrockClient
 from nexus.usecases.inline_agents.instructions import InstructionsUseCase
 from nexus.usecases.inline_agents.mcp_definition_sync import sync_mcp_templates_from_agent_payload
@@ -57,7 +56,13 @@ class UpdateAgentUseCase(ToolsUseCase, InstructionsUseCase):
 
         self.handle_tools(agent_obj, project, agent_data["tools"], files, str(project.uuid))
         self.update_credentials(agent_obj, project, agent_data.get("credentials", {}))
-        self.update_constants(agent_obj, project, agent_data.get("constants", {}))
+        if "constants" in agent_data:
+            sync_agent_constants_from_payload(
+                agent_obj,
+                project,
+                agent_data.get("constants") or {},
+                prune_missing=True,
+            )
 
         old_group = agent_obj.group
 
@@ -125,54 +130,6 @@ class UpdateAgentUseCase(ToolsUseCase, InstructionsUseCase):
         invalidate_team_cache_for_agent_integration_projects(agent_obj)
 
         return agent_data
-
-    def update_constants(self, agent: Agent, project: Project, constants: Dict):
-        if not constants:
-            return
-
-        existing_constants = {row.key: row for row in AgentConstant.objects.filter(project=project)}
-
-        for key, constant_def in constants.items():
-            if not isinstance(constant_def, dict):
-                continue
-            fields = fields_from_yaml_constant(key, constant_def)
-            if key in existing_constants:
-                logger.info(f"Updating constant - key: {key}")
-                row = existing_constants[key]
-                row.label = fields["label"]
-                row.type = fields["type"]
-                row.options = fields["options"]
-                row.default_value = fields["default_value"]
-                row.is_required = fields["is_required"]
-                row.definition = fields["definition"]
-                row.save()
-                if agent not in row.agents.all():
-                    row.agents.add(agent)
-                del existing_constants[key]
-            else:
-                logger.info(f"Creating constant - key: {key}")
-                row = AgentConstant.objects.create(
-                    project=project,
-                    key=fields["key"],
-                    label=fields["label"],
-                    type=fields["type"],
-                    options=fields["options"],
-                    default_value=fields["default_value"],
-                    is_required=fields["is_required"],
-                    definition=fields["definition"],
-                )
-                row.agents.add(agent)
-
-        for row in existing_constants.values():
-            linked_agents = list(row.agents.all())
-            if not linked_agents:
-                logger.info(f"Deleting empty constant - key: {row.key}, project_uuid: {str(project.uuid)}")
-                row.delete()
-            elif len(linked_agents) == 1 and agent in linked_agents:
-                logger.info(f"Deleting constant - key: {row.key}, project_uuid: {str(project.uuid)}")
-                row.delete()
-            elif agent in linked_agents:
-                row.agents.remove(agent)
 
     def update_credentials(self, agent: Agent, project: Project, credentials: Dict):
         if not credentials:


### PR DESCRIPTION
- Introduced the `AgentConstant` model to define agent-level constant definitions, including fields for `key`, `label`, `type`, `options`, `default_value`, and `is_required`, with a unique constraint on `(project, key)`.
- Implemented `create_constants` and `update_constants` methods in `CreateAgentUseCase` and `UpdateAgentUseCase` to persist, sync, and remove agent constants from YAML payloads.
- Added `agent_constant_definitions.py` with helpers for parsing YAML constant definitions (`fields_from_yaml_constant`, `constant_type_from_yaml`, `normalize_constant_options`) and serializing constants for the API (`serialize_agent_constant_for_api`).
- Replaced the previous `_process_constants` approach (which stored constants as a dict on the agent) with database-backed `AgentConstant` records read via `agentconstant_set`.
- Updated the OpenAI adapter's `_prepare_agent_constants` to read constants from `agent.agentconstant_set.all()` instead of `agent.constants`.
- Added `AgentConstantInline` and `AgentConstantAdmin` to the Django admin interface for viewing and managing constants linked to agents.
- Updated catalog serializers to prefetch `agentconstant_set`, expose constants via `_agent_constants_payload`, and merge them into MCP `config` entries or into a synthetic MCP carrier row for standalone agents.
- Extended the synthetic MCP builder (`_synthetic_mcp_for_standalone_agent`) to include both credentials and constants, and updated `_mcps_for_standalone_agent` to emit the synthetic row when either credentials or constants are present.
- Added tests covering constant creation, API payload serialization, and update/sync behavior for agent constants.