### PR TITLE
feat: add spec 001 for project guardrails category configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,5 +199,7 @@ celerybeat-schedule.*
 .cursor/*
 !.cursor/skills/
 !.cursor/skills/speckit-*/
-# Feature specs are added in a follow-up PR
-specs/
+# Feature specs — version 001 only (additional specs in follow-up PRs)
+specs/*
+!specs/001-project-guardrails-config/
+!specs/001-project-guardrails-config/**

--- a/specs/001-project-guardrails-config/checklists/requirements.md
+++ b/specs/001-project-guardrails-config/checklists/requirements.md
@@ -28,3 +28,4 @@
 - 2026-07-06: Rewritten for strict backend scope; confirmation is API contract (`409` / `confirm_disable`), not UI.
 - 2026-07-06 clarify: 5 questions resolved (admin role, new/existing default, default message, PATCH confirmation, catalog merge).
 - 2026-07-06 clarify (naming): *topic* → **guardrail category**; *topic_states* → **category_states**; backend i18n out of scope (T002 dropped).
+- 2026-07-16: Runtime redesigned — `ApplyGuardrail` in Nexus preprocess (INPUT only), one Bedrock guardrail per project, omit unblocked categories on sync, blocking message Option A (Nexus message, ignore Bedrock canned text). Replaced payload/`categories` map for Models + Lambda path.

--- a/specs/001-project-guardrails-config/checklists/requirements.md
+++ b/specs/001-project-guardrails-config/checklists/requirements.md
@@ -1,0 +1,30 @@
+# Specification Quality Checklist: Project Guardrails Topic Configuration
+
+**Purpose**: Validate specification completeness before planning
+**Created**: 2026-07-06
+**Feature**: [spec.md](./spec.md)
+
+## Content Quality
+
+- [x] Focused on backend API and runtime behavior (no frontend scope)
+- [x] User value expressed via API consumer / platform outcomes
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable via API and runtime assertions
+- [x] Success criteria are measurable
+- [x] Edge cases identified
+- [x] Scope bounded (backend only)
+
+## Feature Readiness
+
+- [x] FRs map to acceptance scenarios
+- [x] Out of scope explicitly excludes frontend work
+
+## Notes
+
+- 2026-07-06: Rewritten for strict backend scope; confirmation is API contract (`409` / `confirm_disable`), not UI.
+- 2026-07-06 clarify: 5 questions resolved (admin role, new/existing default, default message, PATCH confirmation, catalog merge).
+- 2026-07-06 clarify (naming): *topic* → **guardrail category**; *topic_states* → **category_states**; backend i18n out of scope (T002 dropped).

--- a/specs/001-project-guardrails-config/contracts/guardrails-config-api.yaml
+++ b/specs/001-project-guardrails-config/contracts/guardrails-config-api.yaml
@@ -1,0 +1,114 @@
+openapi: 3.0.3
+info:
+  title: Project Guardrails Configuration API
+  version: 1.1.0
+  description: Nexus backend — guardrail category block states and blocking message
+
+paths:
+  /api/v1/projects/{project_uuid}/guardrails-config/:
+    get:
+      operationId: getProjectGuardrailsConfig
+      summary: Get project guardrails configuration
+      tags: [Guardrails]
+      parameters:
+        - name: project_uuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GuardrailsConfigResponse"
+    patch:
+      operationId: updateProjectGuardrailsConfig
+      summary: Update guardrails configuration (admin only)
+      tags: [Guardrails]
+      parameters:
+        - name: project_uuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GuardrailsConfigUpdateRequest"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GuardrailsConfigResponse"
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfirmationRequired"
+
+components:
+  schemas:
+    GuardrailCategory:
+      type: object
+      required: [slug, name, description, blocked]
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+          description: English catalog label from settings
+        description:
+          type: string
+          description: English catalog description from settings
+        blocked:
+          type: boolean
+
+    GuardrailsConfigResponse:
+      type: object
+      required: [categories, blocking_message, blocking_message_is_custom, writable]
+      properties:
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/GuardrailCategory"
+        blocking_message:
+          type: string
+          maxLength: 240
+        blocking_message_is_custom:
+          type: boolean
+        writable:
+          type: boolean
+
+    GuardrailsConfigUpdateRequest:
+      type: object
+      properties:
+        category_states:
+          type: object
+          additionalProperties:
+            type: boolean
+          example:
+            politics: true
+            hate: false
+        blocking_message:
+          type: string
+          maxLength: 240
+          nullable: true
+        confirm_disable:
+          type: boolean
+          default: false
+
+    ConfirmationRequired:
+      type: object
+      properties:
+        requires_confirmation:
+          type: boolean
+        confirmation_type:
+          type: string
+          enum: [disable_category, disable_all]
+        detail:
+          type: string

--- a/specs/001-project-guardrails-config/data-model.md
+++ b/specs/001-project-guardrails-config/data-model.md
@@ -11,6 +11,8 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 | slug | string | Stable key, e.g. `politics`, `physical_health` |
 | name | string | English display label (API response) |
 | description | string | English scope description (API response) |
+| bedrock_definition | string | Denied topic definition for Bedrock sync (may equal description) |
+| bedrock_examples | string[] | Optional sample phrases for Bedrock (max 5) |
 
 **Initial slugs (11)**: `politics`, `physical_health`, `sexual_content`, `bias`, `hate`, `religion`, `suicide`, `self_harm`, `beliefs`, `gender_identity`, `sexual_relations`
 
@@ -25,6 +27,8 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 | project | OneToOne → Project | CASCADE | |
 | category_states | JSONField | `{slug: bool}` | `true` = blocked |
 | blocking_message | TextField | null, max 240 | null = use `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` |
+| bedrock_guardrail_identifier | CharField | null/blank until first sync | Bedrock Guardrail id |
+| bedrock_guardrail_version | CharField | null/blank until first sync | Bedrock version string |
 | created_on / modified_on | DateTime | auto | |
 | initialized_as_new_project | Boolean | default False | Audit for lazy init |
 
@@ -34,17 +38,26 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 - Missing slugs filled on read with project-type default.
 - If any category blocked, effective message must be non-empty (custom or settings default).
 
+**Bedrock sync rules**
+
+- Category PATCH → upsert Denied Topics for slugs where `blocked=true` only; persist new identifier/version.
+- Message-only PATCH → local field only; **no** Bedrock update.
+- Existing `Guardrail` model (identifier/version, global/current_version) may be reused or superseded by these fields — implementation MUST keep a single source of truth per project.
+
 ---
 
 ## State Transitions
 
 ```
-blocked --PATCH + confirm_disable--> unblocked
-unblocked --PATCH--> blocked
+blocked --PATCH + confirm_disable--> unblocked --> Bedrock sync (omit category)
+unblocked --PATCH--> blocked --> Bedrock sync (include category)
 
-(no row) --first GET--> lazy init --> row
+(no row) --first GET--> lazy init --> row [--> create/sync Bedrock when any blocked]
+
+ApplyGuardrail INTERVENED --> return project effective message (ignore Bedrock canned text)
 ```
 
 ## Migration notes
 
-- Single migration; no backfill; new catalog slugs merged at read time.
+- Single migration; no backfill of historical conversations; new catalog slugs merged at read time.
+- Bedrock resources created lazily on first sync need (lazy init and/or first category PATCH).

--- a/specs/001-project-guardrails-config/data-model.md
+++ b/specs/001-project-guardrails-config/data-model.md
@@ -1,0 +1,50 @@
+# Data Model: Project Guardrails Category Configuration
+
+## Entities
+
+### GuardrailCategoryCatalogEntry (code constant, not DB)
+
+Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in code, not persisted.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| slug | string | Stable key, e.g. `politics`, `physical_health` |
+| name | string | English display label (API response) |
+| description | string | English scope description (API response) |
+
+**Initial slugs (11)**: `politics`, `physical_health`, `sexual_content`, `bias`, `hate`, `religion`, `suicide`, `self_harm`, `beliefs`, `gender_identity`, `sexual_relations`
+
+> Not to be confused with `nexus.intelligences.models.Topics` (conversation classification).
+
+---
+
+### ProjectGuardrailsConfig (new model in `nexus/projects/models.py`)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| project | OneToOne → Project | CASCADE | |
+| category_states | JSONField | `{slug: bool}` | `true` = blocked |
+| blocking_message | TextField | null, max 240 | null = use `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` |
+| created_on / modified_on | DateTime | auto | |
+| initialized_as_new_project | Boolean | default False | Audit for lazy init |
+
+**Validation**
+
+- `category_states` keys = catalog slugs only; unknown keys stripped on write.
+- Missing slugs filled on read with project-type default.
+- If any category blocked, effective message must be non-empty (custom or settings default).
+
+---
+
+## State Transitions
+
+```
+blocked --PATCH + confirm_disable--> unblocked
+unblocked --PATCH--> blocked
+
+(no row) --first GET--> lazy init --> row
+```
+
+## Migration notes
+
+- Single migration; no backfill; new catalog slugs merged at read time.

--- a/specs/001-project-guardrails-config/plan.md
+++ b/specs/001-project-guardrails-config/plan.md
@@ -1,42 +1,42 @@
-# Implementation Plan: Project Guardrails Topic Configuration
+# Implementation Plan: Project Guardrails Category Configuration
 
-**Branch**: `001-project-guardrails-config` | **Date**: 2026-07-06 | **Spec**: [spec.md](./spec.md)
+**Branch**: `001-project-guardrails-config` | **Date**: 2026-07-16 | **Spec**: [spec.md](./spec.md)
 
-**Scope**: Nexus backend only — models, API, use cases, runtime payload, cache invalidation, tests.
+**Scope**: Nexus backend only — models, API, use cases, Bedrock Guardrail sync, `ApplyGuardrail` preprocess gate, cache invalidation, tests.
 
 ## Summary
 
-Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, confirmation contract (`disable_category` / `disable_all`), extended runtime payload with `categories` map, cache invalidation. No backend i18n.
+Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, confirmation contract (`disable_category` / `disable_all`), **one Bedrock Guardrail per project** synced with only blocked categories, **`ApplyGuardrail` on INPUT** in existing preprocess (Option A message resolution), cache invalidation. No backend i18n. No Lambda for this flow.
 
 ## Technical Context
 
 **Language/Version**: Python 3.11, Django 4.2
 
-**Primary Dependencies**: DRF, drf-spectacular, `GuardrailsUsecase`, `CacheService`, router guardrails handler
+**Primary Dependencies**: DRF, drf-spectacular, boto3 (`bedrock` + `bedrock-runtime`), `GuardrailsUsecase`, `CacheService`, `router/tasks/invoke.py` preprocess
 
-**Storage**: PostgreSQL — `ProjectGuardrailsConfig` (JSONField + TextField)
+**Storage**: PostgreSQL — `ProjectGuardrailsConfig` (JSONField + TextField + Bedrock id/version)
 
-**Testing**: pytest / Django TestCase / APIClient in `nexus/` and `router/`
+**Testing**: pytest / Django TestCase / APIClient in `nexus/` and `router/`; Bedrock clients mocked
 
 **Target Platform**: Linux (Nexus API + Router workers)
 
-**Project Type**: Backend web service (REST API + runtime injection)
+**Project Type**: Backend web service (REST API + pre-input Bedrock gate)
 
-**Performance Goals**: GET/PATCH p95 < 200ms; reuse existing `GUARDRAILS_TTL` cache
+**Performance Goals**: GET/PATCH p95 < 200ms (excluding Bedrock sync); `ApplyGuardrail` on critical path — measure and budget; reuse `GUARDRAILS_TTL` cache for id/version + effective message
 
-**Constraints**: 240-char message; admin-only writes; last-write-wins; no retroactive rewrite
+**Constraints**: 240-char message; admin-only writes; last-write-wins; no retroactive rewrite; INPUT-only; message-only PATCH skips Bedrock update
 
-**Scale/Scope**: All projects; 11 topics v1; uniform per project
+**Scale/Scope**: All projects; 11 categories v1; uniform per project
 
 ## Constitution Check
 
 | Gate | Status |
 |------|--------|
 | Placeholder constitution | PASS (N/A) |
-| Tests for new API + use case | PASS |
+| Tests for new API + use case + ApplyGuardrail path | PASS |
 | Cache invalidation on mutation | PASS |
 | 240-char validation | PASS |
-| Scope: no per-agent / custom topics | PASS |
+| Scope: no per-agent / custom categories / Lambda | PASS |
 
 ## Project Structure
 
@@ -58,18 +58,19 @@ nexus/
 │   ├── models.py                    # ProjectGuardrailsConfig (OneToOne Project)
 │   ├── migrations/
 │   └── api/
-│       ├── routers.py               # route registration
+│       ├── routers.py
 │       ├── views.py                 # ProjectGuardrailsConfigView
 │       ├── serializers.py
 │       └── permissions.py           # GuardrailsConfigAdminPermission
 ├── usecases/guardrails/
-│   ├── guardrails_usecase.py        # extended runtime payload
-│   └── project_guardrails_config.py # get/merge/init/update
+│   ├── guardrails_usecase.py        # resolve config + ApplyGuardrail gate helpers
+│   ├── project_guardrails_config.py # get/merge/init/update
+│   └── bedrock_guardrail_sync.py    # create/update/version Denied Topics subset
 └── settings.py                      # GUARDRAIL_CATEGORY_CATALOG + default message
 
 router/
 ├── services/cache_service.py
-└── tasks/workflow_orchestrator.py
+└── tasks/invoke.py                  # _preprocess_message_input → ApplyGuardrail (INPUT)
 ```
 
 ## Phase 0 — Research

--- a/specs/001-project-guardrails-config/plan.md
+++ b/specs/001-project-guardrails-config/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Project Guardrails Topic Configuration
+
+**Branch**: `001-project-guardrails-config` | **Date**: 2026-07-06 | **Spec**: [spec.md](./spec.md)
+
+**Scope**: Nexus backend only — models, API, use cases, runtime payload, cache invalidation, tests.
+
+## Summary
+
+Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, confirmation contract (`disable_category` / `disable_all`), extended runtime payload with `categories` map, cache invalidation. No backend i18n.
+
+## Technical Context
+
+**Language/Version**: Python 3.11, Django 4.2
+
+**Primary Dependencies**: DRF, drf-spectacular, `GuardrailsUsecase`, `CacheService`, router guardrails handler
+
+**Storage**: PostgreSQL — `ProjectGuardrailsConfig` (JSONField + TextField)
+
+**Testing**: pytest / Django TestCase / APIClient in `nexus/` and `router/`
+
+**Target Platform**: Linux (Nexus API + Router workers)
+
+**Project Type**: Backend web service (REST API + runtime injection)
+
+**Performance Goals**: GET/PATCH p95 < 200ms; reuse existing `GUARDRAILS_TTL` cache
+
+**Constraints**: 240-char message; admin-only writes; last-write-wins; no retroactive rewrite
+
+**Scale/Scope**: All projects; 11 topics v1; uniform per project
+
+## Constitution Check
+
+| Gate | Status |
+|------|--------|
+| Placeholder constitution | PASS (N/A) |
+| Tests for new API + use case | PASS |
+| Cache invalidation on mutation | PASS |
+| 240-char validation | PASS |
+| Scope: no per-agent / custom topics | PASS |
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/001-project-guardrails-config/
+├── spec.md, plan.md, research.md, data-model.md
+├── quickstart.md, tasks.md
+├── contracts/guardrails-config-api.yaml
+└── checklists/requirements.md
+```
+
+### Source Code
+
+```text
+nexus/
+├── projects/
+│   ├── models.py                    # ProjectGuardrailsConfig (OneToOne Project)
+│   ├── migrations/
+│   └── api/
+│       ├── routers.py               # route registration
+│       ├── views.py                 # ProjectGuardrailsConfigView
+│       ├── serializers.py
+│       └── permissions.py           # GuardrailsConfigAdminPermission
+├── usecases/guardrails/
+│   ├── guardrails_usecase.py        # extended runtime payload
+│   └── project_guardrails_config.py # get/merge/init/update
+└── settings.py                      # GUARDRAIL_CATEGORY_CATALOG + default message
+
+router/
+├── services/cache_service.py
+└── tasks/workflow_orchestrator.py
+```
+
+## Phase 0 — Research
+
+Complete → [research.md](./research.md)
+
+## Phase 1 — Design & Contracts
+
+Complete → [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+## Phase 2 — Tasks
+
+→ [tasks.md](./tasks.md)

--- a/specs/001-project-guardrails-config/quickstart.md
+++ b/specs/001-project-guardrails-config/quickstart.md
@@ -5,7 +5,7 @@
 curl -s -H "Authorization: Bearer $TOKEN" \
   "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
 
-# 2. Block a category
+# 2. Block a category (persists + syncs Bedrock Denied Topics subset)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"category_states": {"politics": true}}' \
@@ -17,18 +17,28 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -d '{"category_states": {"politics": false}}' \
   "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
 
-# 4. Unblock with confirm
+# 4. Unblock with confirm (sync omits category from Bedrock)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"category_states": {"politics": false}, "confirm_disable": true}' \
   "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
 
-# 5. Runtime payload
+# 5. Message-only PATCH (no Bedrock version bump)
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"blocking_message": "I cannot help with that request."}' \
+  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+
+# 6. Inspect persisted Bedrock ids + effective message
 python manage.py shell -c "
-from nexus.usecases.guardrails.guardrails_usecase import GuardrailsUsecase
-import json
-print(json.dumps(GuardrailsUsecase.get_guardrail_as_dict('$PROJECT_UUID'), indent=2))
+from nexus.projects.models import ProjectGuardrailsConfig
+c = ProjectGuardrailsConfig.objects.get(project__uuid='$PROJECT_UUID')
+print(c.bedrock_guardrail_identifier, c.bedrock_guardrail_version, c.blocking_message)
 "
 
-pytest nexus/projects/api/tests/test_guardrails_config.py nexus/usecases/guardrails/tests/ -q
+# 7. Runtime: send a user message that hits a blocked category and confirm
+#    the reply is the project message (Option A), not Bedrock canned text.
+#    Ensure preprocess does not call GUARDRAILS_LAYER_LAMBDA.
+
+pytest nexus/projects/api/tests/test_guardrails_config.py nexus/usecases/guardrails/tests/ router/tasks/tests/ -q -k guardrail
 ```

--- a/specs/001-project-guardrails-config/quickstart.md
+++ b/specs/001-project-guardrails-config/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Project Guardrails Configuration (Backend)
+
+```bash
+# 1. GET (lazy init)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+
+# 2. Block a category
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"category_states": {"politics": true}}' \
+  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+
+# 3. Unblock without confirm → 409
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"category_states": {"politics": false}}' \
+  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+
+# 4. Unblock with confirm
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"category_states": {"politics": false}, "confirm_disable": true}' \
+  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+
+# 5. Runtime payload
+python manage.py shell -c "
+from nexus.usecases.guardrails.guardrails_usecase import GuardrailsUsecase
+import json
+print(json.dumps(GuardrailsUsecase.get_guardrail_as_dict('$PROJECT_UUID'), indent=2))
+"
+
+pytest nexus/projects/api/tests/test_guardrails_config.py nexus/usecases/guardrails/tests/ -q
+```

--- a/specs/001-project-guardrails-config/research.md
+++ b/specs/001-project-guardrails-config/research.md
@@ -1,0 +1,34 @@
+# Research: Project Guardrails Category Configuration
+
+## R1 — Naming: category, not topic or instruction
+
+**Decision**: Domain term **guardrail category**. Settings: `GUARDRAIL_CATEGORY_CATALOG`. Persistence: `category_states`. API/runtime: `categories`.
+
+**Rationale**:
+
+- **Topic** is taken: `Topics` model + `lambda_conversation_topics` classify *conversation content*, user-defined per project.
+- **Instruction** is taken: content-base instructions, agent instructions, formatter instructions.
+- **Category** matches FDD intent (fixed sensitive *subject categories*) without overloading existing nouns.
+
+**Rejected**: `guardrails_instructions` — reads as prompt text, not a taxonomy of blocked subjects.
+
+---
+
+## R2 — i18n (backend scope)
+
+**Decision**: **No i18n layer in Nexus for this feature.**
+
+- Catalog `name`/`description`: English strings in settings constant.
+- Default blocking message: `settings.GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` (single string).
+- Custom blocking message: stored as submitted.
+- Remove `Accept-Language` from admin API contract.
+
+**Rationale**: Label localization is a presentation concern for API consumers outside this backend scope. Customer-facing default message localization at inference time is owned by Models/runtime contract if needed later — not admin GET i18n.
+
+**Rejected**: T002 locale module task — frontend/i18n pipeline pattern, not Nexus backend responsibility.
+
+---
+
+## R3 — Admin writes, lazy init, runtime (unchanged logic)
+
+See prior decisions: moderator-only PATCH, deploy timestamp defaults, extend `GuardrailsUsecase` with `categories` + `blocking_message`, cache invalidation on PATCH, `confirm_disable` contract (`disable_category` | `disable_all`).

--- a/specs/001-project-guardrails-config/research.md
+++ b/specs/001-project-guardrails-config/research.md
@@ -2,7 +2,7 @@
 
 ## R1 — Naming: category, not topic or instruction
 
-**Decision**: Domain term **guardrail category**. Settings: `GUARDRAIL_CATEGORY_CATALOG`. Persistence: `category_states`. API/runtime: `categories`.
+**Decision**: Domain term **guardrail category**. Settings: `GUARDRAIL_CATEGORY_CATALOG`. Persistence: `category_states`. API: `categories`.
 
 **Rationale**:
 
@@ -23,12 +23,50 @@
 - Custom blocking message: stored as submitted.
 - Remove `Accept-Language` from admin API contract.
 
-**Rationale**: Label localization is a presentation concern for API consumers outside this backend scope. Customer-facing default message localization at inference time is owned by Models/runtime contract if needed later — not admin GET i18n.
+**Rationale**: Label localization is a presentation concern for API consumers outside this backend scope.
 
-**Rejected**: T002 locale module task — frontend/i18n pipeline pattern, not Nexus backend responsibility.
+**Rejected**: locale module task — frontend/i18n pipeline pattern, not Nexus backend responsibility.
 
 ---
 
-## R3 — Admin writes, lazy init, runtime (unchanged logic)
+## R3 — Admin writes, lazy init, confirmation
 
-See prior decisions: moderator-only PATCH, deploy timestamp defaults, extend `GuardrailsUsecase` with `categories` + `blocking_message`, cache invalidation on PATCH, `confirm_disable` contract (`disable_category` | `disable_all`).
+**Decision**: Moderator/org-admin PATCH only; `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` + lazy init on first GET; `confirm_disable` contract (`disable_category` | `disable_all`); cache invalidation on PATCH.
+
+Unchanged from 2026-07-06 product/API clarifications.
+
+---
+
+## R4 — Runtime: ApplyGuardrail in Nexus, not Lambda
+
+**Decision**: Evaluate every user input with Bedrock Runtime **`ApplyGuardrail`** (`source=INPUT`) in the existing preprocess/`invoke` path. Do **not** use `GUARDRAILS_LAYER_LAMBDA` / conversation lambda for this feature.
+
+**Rationale**: Guardrails run on every message; an extra Lambda hop adds latency (cold start + network). Decision from Roger Alexandre / John: implement Bedrock Guardrails SDK directly in Nexus.
+
+**Rejected**: Re-enabling `guardrails_complexity_layer` Lambda invoke; injecting a `categories` map for Models team to enforce refusal.
+
+---
+
+## R5 — One Bedrock Guardrail per project; omit unblocked categories
+
+**Decision**: Each project owns one Bedrock Guardrail (`identifier` + `version` persisted). On category PATCH, sync Denied Topics to include **only** `blocked=true` catalog entries. Unblocked categories are omitted from the policy.
+
+**Rationale**: Bedrock evaluates configured denied topics as a set; toggles are expressed by presence/absence in the guardrail definition, not by a separate runtime map.
+
+**When all unblocked**: skip `ApplyGuardrail` at preprocess (no-op).
+
+---
+
+## R6 — Blocking message Option A
+
+**Decision**: On `GUARDRAIL_INTERVENED`, Nexus ignores Bedrock canned output and returns the project effective message (custom or `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`). Message-only PATCH does not UpdateGuardrail / bump version.
+
+**Rationale**: Message changes are more frequent than topic toggles; avoids unnecessary Bedrock version churn. Customer-facing copy stays owned by Nexus/project config.
+
+**Rejected**: Option B — store project message in `blockedInputMessaging` and return Bedrock text as-is.
+
+---
+
+## R7 — Fail behavior on Bedrock errors (open)
+
+**Decision pending implementation**: Document and test whether preprocess **fail-open** (allow message) or **fail-closed** (block/safe reply) when `ApplyGuardrail` or sync APIs error. Prefer explicit choice in plan/tasks before release.

--- a/specs/001-project-guardrails-config/spec.md
+++ b/specs/001-project-guardrails-config/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: Project Guardrails Category Configuration
+
+**Feature Branch**: `001-project-guardrails-config`
+
+**Created**: 2026-07-06
+
+**Status**: Draft
+
+**Input**: FDD V2 — Configuração de tópicos de guardrails por projeto (Jade Castro, 2026-06-23)
+
+**Scope**: Nexus backend only — persistence, API, validation, runtime injection, cache. No frontend or UI work in this feature.
+
+**Terminology**: Use **guardrail category** (not *topic*) to avoid collision with conversation `Topics` (`nexus.intelligences.models.Topics`, lambda classifier). Use **category** (not *instruction*) to avoid collision with agent/content-base instructions.
+
+## Clarifications
+
+### Session 2026-07-06
+
+- Q: Who may write guardrails configuration via API? → A: Project **moderator** or **organization admin** only.
+- Q: New vs existing project defaults? → A: `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` + lazy init on first GET.
+- Q: Default blocking message? → A: `settings.GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` until custom message is saved; custom stored verbatim, no auto-translation.
+- Q: PATCH confirmation? → A: `confirm_disable: true` required when unblocking categories; `disable_all` when all unblocked.
+- Q: New catalog entries? → A: Merge on GET; missing slugs inherit project-type default.
+
+### Session 2026-07-06
+
+- Q: Rename away from *topic*? → A: **guardrail category** / `category_states` / `GUARDRAIL_CATEGORY_CATALOG`. Rejects *instruction* (conflicts with existing Instructions domain) and *topic* (conflicts with conversation Topics).
+- Q: Backend i18n for catalog labels? → A: **Out of scope.** API returns English `name`/`description` from code constant. No `Accept-Language`, no locale module. Default blocking message is a single settings string.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read and update category blocked states (Priority: P1)
+
+As an authenticated admin API consumer, I need to read and update per-category blocked states for a project so guardrail behavior can be controlled without engineering intervention.
+
+**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked with confirmation, verify runtime payload reflects change.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid project UUID and auth, **When** `GET /guardrails-config/`, **Then** response lists all fixed catalog categories with `slug`, `name`, `description`, and `blocked`.
+2. **Given** category blocked, **When** PATCH unblocks without `confirm_disable`, **Then** `409` with `confirmation_type: disable_category`.
+3. **Given** PATCH unblock with `confirm_disable: true`, **Then** persists and runtime reflects unblocked category.
+4. **Given** category unblocked, **When** PATCH blocks without confirmation, **Then** persists immediately.
+5. **Given** PATCH unblocks all categories without `confirm_disable`, **Then** `409` with `confirmation_type: disable_all`.
+6. **Given** PATCH unblocks all with `confirm_disable: true`, **Then** all categories unblocked.
+
+---
+
+### User Story 2 - Configure blocking message (Priority: P2)
+
+As an authenticated admin API consumer, I need to persist a project blocking message for customer-facing refusals.
+
+**Independent Test**: PATCH message ≤240 chars; runtime uses exact message on block.
+
+**Acceptance Scenarios**:
+
+1. **Given** no custom message, **When** GET, **Then** `blocking_message` is platform default from settings and `blocking_message_is_custom: false`.
+2. **Given** category blocked, **When** customer message triggers guardrail at runtime, **Then** router returns project blocking message.
+3. **Given** PATCH message ≤240 chars, **When** saved, **Then** GET and runtime use custom message.
+4. **Given** PATCH message >240 chars, **When** validated, **Then** `400`.
+
+---
+
+### User Story 3 - Uniform runtime application (Priority: P1)
+
+As the platform, guardrails config MUST apply uniformly to all agents in the project.
+
+**Independent Test**: `GuardrailsUsecase` payload identical for all agents; updates after PATCH + cache invalidation.
+
+**Acceptance Scenarios**:
+
+1. **Given** new project, **When** first GET lazy init, **Then** all categories blocked + platform default message.
+2. **Given** existing project, **When** first GET lazy init, **Then** all categories unblocked + platform default message.
+3. **Given** PATCH applied, **When** next message processed, **Then** new payload used; prior responses unchanged.
+
+---
+
+### Edge Cases
+
+- Multiple blocked categories match one message → single blocking message (not per-category).
+- Empty/whitespace `blocking_message` while any category blocked → `400`.
+- Config changed mid-conversation → applies after save only.
+- New catalog slug in deploy → merged on GET with project-type default.
+- Non-admin PATCH → `403`; GET returns `writable: false`.
+- Concurrent PATCH → last write wins.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: API MUST expose GET/PATCH with full fixed **guardrail category** catalog (`slug`, `name`, `description`, `blocked`).
+- **FR-002**: `blocked: true` = category refused; `blocked: false` = allowed.
+- **FR-003**: PATCH persists `category_states` at project level for admin only.
+- **FR-004**: PATCH returns `403` for non-admin.
+- **FR-005**: One blocking message per project for all blocked categories and agents.
+- **FR-006**: Reject blocking messages >240 characters.
+- **FR-007**: Reject empty/whitespace blocking message when any category blocked.
+- **FR-008**: Lazy init defaults all categories blocked (new) or unblocked (existing).
+- **FR-009**: PATCH unblocking categories requires `confirm_disable: true` or returns `409`.
+- **FR-010**: PATCH unblocking all categories returns `409` with `disable_all` unless confirmed.
+- **FR-011**: PATCH blocking categories does NOT require confirmation.
+- **FR-012**: Runtime exposes `categories` map + `blocking_message` in guardrails payload.
+- **FR-013**: Changes apply only to messages after successful PATCH.
+- **FR-014**: GET merges new catalog slugs with project-type defaults.
+- **FR-015**: GET returns platform default blocking message from settings when no custom message stored.
+- **FR-016**: Custom blocking messages stored without auto-translation.
+- **FR-017**: No operator CRUD on catalog category definitions.
+- **FR-018**: No per-agent guardrails config in this release.
+- **FR-019**: No per-category blocking messages in this release.
+
+### Key Entities
+
+- **Guardrail category (catalog entry)**: Platform slug + English label/description; not mutable via API.
+- **Project guardrails configuration**: One-to-one with project; `category_states` + optional custom blocking message.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Admin can GET/PATCH all 11 categories + message in one API session.
+- **SC-002**: 100% of over-limit message PATCH attempts return `400`.
+- **SC-003**: After PATCH, runtime payload reflects new states on next cache fetch.
+- **SC-004**: 100% of non-admin PATCH return `403`.
+- **SC-005**: First GET: new projects all blocked; existing all unblocked.
+- **SC-006**: 100% of unconfirmed disable PATCH return `409` with typed metadata.
+
+## Assumptions
+
+- Conversation **Topics** (`Topics` model, lambda classifier) are a separate domain — no shared tables or APIs.
+- Catalog labels in API are **English strings** from `GUARDRAIL_CATEGORY_CATALOG` (display localization is out of backend scope).
+- Models team consumes `categories` map from runtime payload.
+
+## Out of Scope
+
+- Conversation topic classification
+- Per-agent guardrails, custom categories, per-category messages, auto-translation
+- Frontend/UI, API `Accept-Language`, backend locale modules
+
+## API References
+
+| Method | Route |
+|--------|-------|
+| GET | `/api/v1/projects/{project_uuid}/guardrails-config/` |
+| PATCH | `/api/v1/projects/{project_uuid}/guardrails-config/` |
+
+## Dependencies
+
+| Dependency | Owner |
+|------------|-------|
+| Category refusal at inference | AI Models team |
+| Persistence & injection | Nexus backend |

--- a/specs/001-project-guardrails-config/spec.md
+++ b/specs/001-project-guardrails-config/spec.md
@@ -8,7 +8,7 @@
 
 **Input**: FDD V2 — Configuração de tópicos de guardrails por projeto (Jade Castro, 2026-06-23)
 
-**Scope**: Nexus backend only — persistence, API, validation, runtime injection, cache. No frontend or UI work in this feature.
+**Scope**: Nexus backend only — persistence, API, validation, Bedrock Guardrail sync (one per project), `ApplyGuardrail` on user input preprocess, cache. No frontend or UI work in this feature.
 
 **Terminology**: Use **guardrail category** (not *topic*) to avoid collision with conversation `Topics` (`nexus.intelligences.models.Topics`, lambda classifier). Use **category** (not *instruction*) to avoid collision with agent/content-base instructions.
 
@@ -27,22 +27,30 @@
 - Q: Rename away from *topic*? → A: **guardrail category** / `category_states` / `GUARDRAIL_CATEGORY_CATALOG`. Rejects *instruction* (conflicts with existing Instructions domain) and *topic* (conflicts with conversation Topics).
 - Q: Backend i18n for catalog labels? → A: **Out of scope.** API returns English `name`/`description` from code constant. No `Accept-Language`, no locale module. Default blocking message is a single settings string.
 
+### Session 2026-07-16
+
+- Q: Where does the refusal check run? → A: **`ApplyGuardrail` in Nexus preprocess**, before each user input. Not via conversation/guardrails Lambda.
+- Q: One Bedrock guardrail per project? → A: **Yes.** Categories with `blocked=false` are **omitted** from the Bedrock Denied Topics policy (not passed as inactive entries).
+- Q: Blocking message source? → A: **Option A** — on `GUARDRAIL_INTERVENED`, Nexus **ignores** Bedrock canned text and returns the project custom message or `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`. Message-only PATCH does **not** require Bedrock UpdateGuardrail.
+- Q: INPUT and/or OUTPUT? → A: **INPUT only** (`source=INPUT`).
+- Q: OpenAI vs Bedrock backends? → A: Reuse the existing preprocess/`invoke` path for both; do not invent a parallel pipeline.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Read and update category blocked states (Priority: P1)
 
 As an authenticated admin API consumer, I need to read and update per-category blocked states for a project so guardrail behavior can be controlled without engineering intervention.
 
-**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked with confirmation, verify runtime payload reflects change.
+**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked with confirmation, verify Bedrock sync omits the unblocked category and the next input no longer blocks that category.
 
 **Acceptance Scenarios**:
 
 1. **Given** valid project UUID and auth, **When** `GET /guardrails-config/`, **Then** response lists all fixed catalog categories with `slug`, `name`, `description`, and `blocked`.
 2. **Given** category blocked, **When** PATCH unblocks without `confirm_disable`, **Then** `409` with `confirmation_type: disable_category`.
-3. **Given** PATCH unblock with `confirm_disable: true`, **Then** persists and runtime reflects unblocked category.
-4. **Given** category unblocked, **When** PATCH blocks without confirmation, **Then** persists immediately.
+3. **Given** PATCH unblock with `confirm_disable: true`, **Then** persists, syncs Bedrock guardrail without that category, and runtime no longer blocks it.
+4. **Given** category unblocked, **When** PATCH blocks without confirmation, **Then** persists immediately and syncs Bedrock including that category.
 5. **Given** PATCH unblocks all categories without `confirm_disable`, **Then** `409` with `confirmation_type: disable_all`.
-6. **Given** PATCH unblocks all with `confirm_disable: true`, **Then** all categories unblocked.
+6. **Given** PATCH unblocks all with `confirm_disable: true`, **Then** all categories unblocked and Bedrock sync reflects no denied categories (runtime skips `ApplyGuardrail` or never intervenes).
 
 ---
 
@@ -50,39 +58,41 @@ As an authenticated admin API consumer, I need to read and update per-category b
 
 As an authenticated admin API consumer, I need to persist a project blocking message for customer-facing refusals.
 
-**Independent Test**: PATCH message ≤240 chars; runtime uses exact message on block.
+**Independent Test**: PATCH message ≤240 chars; on `ApplyGuardrail` intervene, response uses project message (not Bedrock canned text).
 
 **Acceptance Scenarios**:
 
 1. **Given** no custom message, **When** GET, **Then** `blocking_message` is platform default from settings and `blocking_message_is_custom: false`.
-2. **Given** category blocked, **When** customer message triggers guardrail at runtime, **Then** router returns project blocking message.
-3. **Given** PATCH message ≤240 chars, **When** saved, **Then** GET and runtime use custom message.
+2. **Given** category blocked, **When** customer message triggers `ApplyGuardrail` at preprocess, **Then** Nexus returns project blocking message (Option A).
+3. **Given** PATCH message ≤240 chars, **When** saved, **Then** GET reflects custom message; next intervene uses it **without** Bedrock guardrail version bump for message-only change.
 4. **Given** PATCH message >240 chars, **When** validated, **Then** `400`.
 
 ---
 
 ### User Story 3 - Uniform runtime application (Priority: P1)
 
-As the platform, guardrails config MUST apply uniformly to all agents in the project.
+As the platform, guardrails config MUST apply uniformly to all agents in the project via a single pre-input check.
 
-**Independent Test**: `GuardrailsUsecase` payload identical for all agents; updates after PATCH + cache invalidation.
+**Independent Test**: Same project Bedrock guardrail + project message used in preprocess for every agent/backend path that shares `invoke` preprocess; updates after category PATCH + Bedrock sync + cache invalidation.
 
 **Acceptance Scenarios**:
 
-1. **Given** new project, **When** first GET lazy init, **Then** all categories blocked + platform default message.
-2. **Given** existing project, **When** first GET lazy init, **Then** all categories unblocked + platform default message.
-3. **Given** PATCH applied, **When** next message processed, **Then** new payload used; prior responses unchanged.
+1. **Given** new project, **When** first GET lazy init, **Then** all categories blocked + platform default message + Bedrock guardrail created/synced with all catalog denied topics.
+2. **Given** existing project, **When** first GET lazy init, **Then** all categories unblocked + platform default message (no denied topics on Bedrock / skip apply as defined).
+3. **Given** category PATCH applied and synced, **When** next user input is processed, **Then** `ApplyGuardrail` uses the new guardrail version; prior responses unchanged.
 
 ---
 
 ### Edge Cases
 
-- Multiple blocked categories match one message → single blocking message (not per-category).
+- Multiple blocked categories match one message → single project blocking message (not per-category).
 - Empty/whitespace `blocking_message` while any category blocked → `400`.
-- Config changed mid-conversation → applies after save only.
-- New catalog slug in deploy → merged on GET with project-type default.
+- Config changed mid-conversation → applies after successful PATCH (+ Bedrock sync when categories change) only.
+- New catalog slug in deploy → merged on GET with project-type default; next category sync includes it when blocked.
 - Non-admin PATCH → `403`; GET returns `writable: false`.
 - Concurrent PATCH → last write wins.
+- Bedrock sync failure on category PATCH → PATCH MUST NOT leave local config and Bedrock permanently inconsistent without a defined error path (fail the request or report sync error; do not silently succeed).
+- All categories unblocked → do not call `ApplyGuardrail` (or equivalent no-op with empty denied topics).
 
 ## Requirements *(mandatory)*
 
@@ -99,40 +109,50 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 - **FR-009**: PATCH unblocking categories requires `confirm_disable: true` or returns `409`.
 - **FR-010**: PATCH unblocking all categories returns `409` with `disable_all` unless confirmed.
 - **FR-011**: PATCH blocking categories does NOT require confirmation.
-- **FR-012**: Runtime exposes `categories` map + `blocking_message` in guardrails payload.
-- **FR-013**: Changes apply only to messages after successful PATCH.
+- **FR-012**: Runtime MUST evaluate each user input with Bedrock `ApplyGuardrail` (`source=INPUT`) using the project's guardrail identifier/version **before** agent processing, reusing the existing preprocess/`invoke` path (no dedicated OpenAI-only pipeline; no `GUARDRAILS_LAYER_LAMBDA` for this flow).
+- **FR-013**: Changes apply only to messages after successful PATCH (and successful Bedrock sync when categories change).
 - **FR-014**: GET merges new catalog slugs with project-type defaults.
 - **FR-015**: GET returns platform default blocking message from settings when no custom message stored.
 - **FR-016**: Custom blocking messages stored without auto-translation.
 - **FR-017**: No operator CRUD on catalog category definitions.
 - **FR-018**: No per-agent guardrails config in this release.
 - **FR-019**: No per-category blocking messages in this release.
+- **FR-020**: Each project MUST have at most one Bedrock Guardrail resource; identifier and version MUST be persisted with the project config.
+- **FR-021**: On category-state PATCH, Nexus MUST sync Bedrock Denied Topics to include **only** categories with `blocked=true` (omit unblocked categories).
+- **FR-022**: On `GUARDRAIL_INTERVENED`, Nexus MUST return the project effective blocking message and MUST NOT use Bedrock canned output text as the customer-facing reply (Option A).
+- **FR-023**: Message-only PATCH MUST persist locally and MUST NOT require Bedrock UpdateGuardrail / version bump.
+- **FR-024**: Guardrail evaluation is INPUT-only; OUTPUT evaluation is out of scope.
+- **FR-025**: When no categories are blocked, runtime MUST skip `ApplyGuardrail` (or equivalent no intervention).
 
 ### Key Entities
 
-- **Guardrail category (catalog entry)**: Platform slug + English label/description; not mutable via API.
-- **Project guardrails configuration**: One-to-one with project; `category_states` + optional custom blocking message.
+- **Guardrail category (catalog entry)**: Platform slug + English label/description (+ Bedrock denied-topic definition/examples as needed); not mutable via API.
+- **Project guardrails configuration**: One-to-one with project; `category_states` + optional custom blocking message + Bedrock guardrail identifier/version.
 
 ## Success Criteria *(mandatory)*
 
 - **SC-001**: Admin can GET/PATCH all 11 categories + message in one API session.
 - **SC-002**: 100% of over-limit message PATCH attempts return `400`.
-- **SC-003**: After PATCH, runtime payload reflects new states on next cache fetch.
+- **SC-003**: After category PATCH + Bedrock sync, the next user input is evaluated with the updated denied-topic set; on intervene, customer receives the project effective message (Option A).
 - **SC-004**: 100% of non-admin PATCH return `403`.
 - **SC-005**: First GET: new projects all blocked; existing all unblocked.
 - **SC-006**: 100% of unconfirmed disable PATCH return `409` with typed metadata.
+- **SC-007**: Preprocess guardrail path does not invoke `GUARDRAILS_LAYER_LAMBDA` for this feature.
 
 ## Assumptions
 
 - Conversation **Topics** (`Topics` model, lambda classifier) are a separate domain — no shared tables or APIs.
 - Catalog labels in API are **English strings** from `GUARDRAIL_CATEGORY_CATALOG` (display localization is out of backend scope).
-- Models team consumes `categories` map from runtime payload.
+- Bedrock Denied Topics are the enforcement mechanism; Nexus owns sync + `ApplyGuardrail` + customer-facing message resolution.
+- Fail-open vs fail-closed on Bedrock API errors during preprocess is an implementation decision to document in research/plan and cover with tests.
 
 ## Out of Scope
 
 - Conversation topic classification
 - Per-agent guardrails, custom categories, per-category messages, auto-translation
 - Frontend/UI, API `Accept-Language`, backend locale modules
+- OUTPUT guardrail evaluation
+- Reintroducing Lambda-based guardrails complexity layer for this flow
 
 ## API References
 
@@ -145,5 +165,6 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 
 | Dependency | Owner |
 |------------|-------|
-| Category refusal at inference | AI Models team |
-| Persistence & injection | Nexus backend |
+| Bedrock Guardrails create/update/version + `ApplyGuardrail` | Nexus backend |
+| Persistence, admin API, preprocess gate, cache | Nexus backend |
+| IAM / AWS account access for Bedrock Guardrails | Platform / DevOps |

--- a/specs/001-project-guardrails-config/tasks.md
+++ b/specs/001-project-guardrails-config/tasks.md
@@ -4,11 +4,11 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Add `GUARDRAIL_CATEGORY_CATALOG`, `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`, and `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` to `nexus/settings.py`
+- [ ] T001 Add `GUARDRAIL_CATEGORY_CATALOG` (incl. Bedrock definition/examples), `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`, and `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` to `nexus/settings.py`
 
 ## Phase 2: Foundational
 
-- [ ] T002 Create `ProjectGuardrailsConfig` model in `nexus/projects/models.py` with `category_states` JSONField and `clean()`
+- [ ] T002 Create `ProjectGuardrailsConfig` model in `nexus/projects/models.py` with `category_states`, `blocking_message`, `bedrock_guardrail_identifier`, `bedrock_guardrail_version`, and `clean()`
 - [ ] T003 Add migration in `nexus/projects/migrations/`
 - [ ] T004 [P] Implement `ProjectGuardrailsConfigUseCase` in `nexus/usecases/guardrails/project_guardrails_config.py`
 - [ ] T005 [P] Add `GuardrailsConfigAdminPermission` in `nexus/projects/api/permissions.py`
@@ -24,23 +24,31 @@
 ## Phase 4: User Story 2 — Blocking message (P2)
 
 - [ ] T011 [US2] Message validation (240 chars, non-empty when blocked) in serializers
-- [ ] T012 [P] [US2] Message validation tests
+- [ ] T012 [P] [US2] Message validation tests (message-only PATCH does not call Bedrock update)
 
-## Phase 5: User Story 3 — Runtime (P1)
+## Phase 5: Bedrock sync (P1)
 
-- [ ] T013 [US3] Extend `GuardrailsUsecase.get_guardrail_as_dict` with `categories` + `blocking_message`
-- [ ] T014 [US3] Cache invalidation on PATCH
-- [ ] T015 [US3] Verify router block path uses config message if needed
-- [ ] T016 [P] [US3] Use case + catalog merge tests in `nexus/usecases/guardrails/tests/`
+- [ ] T013 [US1/US3] Implement Bedrock sync service (`create`/`update`/`version`) with Denied Topics = only `blocked=true` categories
+- [ ] T014 [US1/US3] Wire category PATCH → sync; persist identifier/version; fail request on sync failure
+- [ ] T015 [P] Sync unit tests (omit unblocked; all-unblocked; mock boto3)
 
-## Phase 6: Polish
+## Phase 6: User Story 3 — Runtime ApplyGuardrail (P1)
 
-- [ ] T017 [P] drf-spectacular annotations on view
-- [ ] T018 Run `quickstart.md` scenarios
-- [ ] T019 [P] Django admin read-only in `nexus/projects/admin.py`
+- [ ] T016 [US3] Preprocess gate in `router/tasks/invoke.py`: `ApplyGuardrail` `source=INPUT`; skip when no categories blocked; **no** `GUARDRAILS_LAYER_LAMBDA`
+- [ ] T017 [US3] On `GUARDRAIL_INTERVENED`, return project effective blocking message (Option A); reuse existing early-exit / `UnsafeMessageException` patterns
+- [ ] T018 [US3] Cache id/version + effective message; invalidate on PATCH
+- [ ] T019 [P] [US3] Router/usecase tests: intervene → project message; pass-through; skip when all unblocked; no Lambda invoke
+
+## Phase 7: Polish
+
+- [ ] T020 [P] drf-spectacular annotations on view
+- [ ] T021 Run `quickstart.md` scenarios
+- [ ] T022 [P] Django admin read-only in `nexus/projects/admin.py`
 
 ---
 
-**Removed**: former T002 i18n locale task — out of backend scope.
+**Removed**: former i18n locale task — out of backend scope.
 
-**MVP**: Phases 1–3 + T013.
+**Removed**: “extend runtime payload with `categories` map for Models” — replaced by ApplyGuardrail + Option A.
+
+**MVP**: Phases 1–3 + Phase 5–6 (API + sync + preprocess gate).

--- a/specs/001-project-guardrails-config/tasks.md
+++ b/specs/001-project-guardrails-config/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Project Guardrails Category Configuration
+
+**Scope**: Nexus backend only
+
+## Phase 1: Setup
+
+- [ ] T001 Add `GUARDRAIL_CATEGORY_CATALOG`, `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`, and `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` to `nexus/settings.py`
+
+## Phase 2: Foundational
+
+- [ ] T002 Create `ProjectGuardrailsConfig` model in `nexus/projects/models.py` with `category_states` JSONField and `clean()`
+- [ ] T003 Add migration in `nexus/projects/migrations/`
+- [ ] T004 [P] Implement `ProjectGuardrailsConfigUseCase` in `nexus/usecases/guardrails/project_guardrails_config.py`
+- [ ] T005 [P] Add `GuardrailsConfigAdminPermission` in `nexus/projects/api/permissions.py`
+
+## Phase 3: User Story 1 — Category blocked states (P1)
+
+- [ ] T006 [US1] Serializers in `nexus/projects/api/serializers.py` (`categories` in response, `category_states` in PATCH)
+- [ ] T007 [US1] `ProjectGuardrailsConfigView` GET/PATCH in `nexus/projects/api/views.py`
+- [ ] T008 [US1] Route in `nexus/projects/api/routers.py`
+- [ ] T009 [US1] Confirmation logic (`409`, `disable_category`, `disable_all`) in use case
+- [ ] T010 [P] [US1] Tests in `nexus/projects/api/tests/test_guardrails_config.py`
+
+## Phase 4: User Story 2 — Blocking message (P2)
+
+- [ ] T011 [US2] Message validation (240 chars, non-empty when blocked) in serializers
+- [ ] T012 [P] [US2] Message validation tests
+
+## Phase 5: User Story 3 — Runtime (P1)
+
+- [ ] T013 [US3] Extend `GuardrailsUsecase.get_guardrail_as_dict` with `categories` + `blocking_message`
+- [ ] T014 [US3] Cache invalidation on PATCH
+- [ ] T015 [US3] Verify router block path uses config message if needed
+- [ ] T016 [P] [US3] Use case + catalog merge tests in `nexus/usecases/guardrails/tests/`
+
+## Phase 6: Polish
+
+- [ ] T017 [P] drf-spectacular annotations on view
+- [ ] T018 Run `quickstart.md` scenarios
+- [ ] T019 [P] Django admin read-only in `nexus/projects/admin.py`
+
+---
+
+**Removed**: former T002 i18n locale task — out of backend scope.
+
+**MVP**: Phases 1–3 + T013.


### PR DESCRIPTION
## Version Speckit artifacts for project guardrails category configuration

(spec, plan, tasks, contracts, data model, quickstart).
Allow `specs/001-project-guardrails-config` in `.gitignore`.

Adds the full spec suite for feature `001-project-guardrails-config`, covering:

- **Spec**: backend-scoped requirements for per-project guardrail category blocked states and blocking message, with `confirm_disable` / `409` confirmation contract, lazy init, and admin-only PATCH (`FR-001`–`FR-019`)
- **Data model**: `ProjectGuardrailsConfig` (OneToOne → Project, `category_states` JSONField, `blocking_message` TextField ≤240 chars) and `GUARDRAIL_CATEGORY_CATALOG` settings constant (11 slugs, English labels, not persisted)
- **API contract**: OpenAPI 3.0 for `GET`/`PATCH /api/v1/projects/{project_uuid}/guardrails-config/`, including `409 ConfirmationRequired` schema with `disable_category` / `disable_all` types
- **Plan**: phased implementation across models, use cases, serializers, view, permissions, runtime payload extension, and cache invalidation
- **Tasks**: 19 tasks across 6 phases; i18n locale task dropped as out of backend scope
- **Quickstart**: curl and pytest commands covering lazy init, block, unblock-without-confirm (`409`), unblock-with-confirm, and runtime payload inspection
- **Requirements checklist**: all items resolved; naming settled as _guardrail category_ / `category_states` / `GUARDRAIL_CATEGORY_CATALOG` to avoid collision with conversation `Topics` and agent instructions domains