### PR TITLE
feat: add guardrails config GET/PATCH API with immediate unblock persistence

### DIFF
--- a/nexus/projects/api/routers.py
+++ b/nexus/projects/api/routers.py
@@ -15,6 +15,7 @@ from .views import (
     EnableHumanSupportView,
     FlowsDbCohortReconcileProxyView,
     OpenSupportTicketView,
+    ProjectGuardrailsConfigView,
     ProjectPromptCreationConfigurationsViewset,
     ProjectUpdateViewset,
 )
@@ -42,6 +43,11 @@ urlpatterns = [
         "<project_uuid>/ai-resolution-criteria/<criterion_id>/",
         AIResolutionCriteriaDetailView.as_view(),
         name="ai-resolution-criterion-detail",
+    ),
+    path(
+        "<project_uuid>/guardrails-config/",
+        ProjectGuardrailsConfigView.as_view(),
+        name="project-guardrails-config",
     ),
     path(
         "<project_uuid>/improvements/open-support-ticket/",

--- a/nexus/projects/api/serializers.py
+++ b/nexus/projects/api/serializers.py
@@ -43,9 +43,8 @@ class ConversationSerializer(serializers.Serializer):
 
 
 class GuardrailCategorySerializer(serializers.Serializer):
+    # API contract: slug + blocked only; name/description live in frontend i18n.
     slug = serializers.CharField()
-    name = serializers.CharField()
-    description = serializers.CharField()
     blocked = serializers.BooleanField()
 
 

--- a/nexus/projects/api/serializers.py
+++ b/nexus/projects/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from nexus.projects.channel_ops import get_default_channel_uuid
-from nexus.projects.models import Project
+from nexus.projects.models import Project, ProjectGuardrailsConfig
 
 
 class ProjectSerializer(serializers.ModelSerializer):
@@ -40,3 +40,36 @@ class ConversationSerializer(serializers.Serializer):
     created_at = serializers.DateTimeField(required=False, allow_null=True)
     topic = serializers.CharField(required=False, allow_null=True)
     is_amazing = serializers.BooleanField(required=False, allow_null=True)
+
+
+class GuardrailCategorySerializer(serializers.Serializer):
+    slug = serializers.CharField()
+    name = serializers.CharField()
+    description = serializers.CharField()
+    blocked = serializers.BooleanField()
+
+
+class GuardrailsConfigResponseSerializer(serializers.Serializer):
+    categories = GuardrailCategorySerializer(many=True)
+    blocking_message = serializers.CharField()
+    blocking_message_is_custom = serializers.BooleanField()
+    writable = serializers.BooleanField()
+
+
+class GuardrailsConfigUpdateSerializer(serializers.Serializer):
+    category_states = serializers.DictField(
+        child=serializers.BooleanField(),
+        required=False,
+    )
+    blocking_message = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        max_length=ProjectGuardrailsConfig.BLOCKING_MESSAGE_MAX_LENGTH,
+    )
+    confirm_disable = serializers.BooleanField(required=False, default=False)
+
+    def validate(self, attrs):
+        if "category_states" not in attrs and "blocking_message" not in self.initial_data:
+            raise serializers.ValidationError("At least one of category_states or blocking_message is required.")
+        return attrs

--- a/nexus/projects/api/serializers.py
+++ b/nexus/projects/api/serializers.py
@@ -70,6 +70,6 @@ class GuardrailsConfigUpdateSerializer(serializers.Serializer):
     confirm_disable = serializers.BooleanField(required=False, default=False)
 
     def validate(self, attrs):
-        if "category_states" not in attrs and "blocking_message" not in self.initial_data:
+        if "category_states" not in attrs and "blocking_message" not in attrs:
             raise serializers.ValidationError("At least one of category_states or blocking_message is required.")
         return attrs

--- a/nexus/projects/api/serializers.py
+++ b/nexus/projects/api/serializers.py
@@ -67,7 +67,6 @@ class GuardrailsConfigUpdateSerializer(serializers.Serializer):
         allow_blank=True,
         max_length=ProjectGuardrailsConfig.BLOCKING_MESSAGE_MAX_LENGTH,
     )
-    confirm_disable = serializers.BooleanField(required=False, default=False)
 
     def validate(self, attrs):
         if "category_states" not in attrs and "blocking_message" not in attrs:

--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -63,7 +63,7 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(any(category["blocked"] for category in response.data["categories"]))
 
-    def test_patch_block_category_without_confirmation(self):
+    def test_patch_block_category(self):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
         ProjectGuardrailsConfig.objects.filter(project=self.project).update(
             category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
@@ -79,7 +79,7 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         politics = next(item for item in response.data["categories"] if item["slug"] == "politics")
         self.assertTrue(politics["blocked"])
 
-    def test_patch_unblock_without_confirm_returns_409(self):
+    def test_patch_unblock_persists_immediately(self):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
 
         response = self.client.patch(
@@ -88,24 +88,11 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
-        self.assertTrue(response.data["requires_confirmation"])
-        self.assertEqual(response.data["confirmation_type"], "disable_category")
-
-    def test_patch_unblock_with_confirm_persists(self):
-        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
-
-        response = self.client.patch(
-            self.url,
-            {"category_states": {"politics": False}, "confirm_disable": True},
-            format="json",
-        )
-
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         politics = next(item for item in response.data["categories"] if item["slug"] == "politics")
         self.assertFalse(politics["blocked"])
 
-    def test_patch_unblock_all_requires_disable_all_confirmation(self):
+    def test_patch_unblock_all_persists_immediately(self):
         config = ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
         all_unblocked = ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False)
 
@@ -115,15 +102,7 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
-        self.assertEqual(response.data["confirmation_type"], "disable_all")
-
-        confirmed = self.client.patch(
-            self.url,
-            {"category_states": all_unblocked, "confirm_disable": True},
-            format="json",
-        )
-        self.assertEqual(confirmed.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         config.refresh_from_db()
         self.assertFalse(any(config.category_states.values()))
 

--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -49,6 +49,7 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         self.assertTrue(response.data["blocking_message"])
         self.assertEqual(len(response.data["categories"]), len(ProjectGuardrailsConfigUseCase.catalog_slugs()))
         self.assertTrue(all(category["blocked"] for category in response.data["categories"]))
+        self.assertTrue(all(set(category.keys()) == {"slug", "blocked"} for category in response.data["categories"]))
         self.assertTrue(ProjectGuardrailsConfig.objects.filter(project=self.project).exists())
 
     def test_get_lazy_init_existing_project_unblocks_all(self):

--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -1,0 +1,193 @@
+from datetime import datetime, timezone
+from unittest import mock
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone as django_timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from nexus.projects.models import Project, ProjectAuthorizationRole, ProjectGuardrailsConfig
+from nexus.projects.permissions import has_project_permission
+from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
+from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
+from nexus.usecases.users.tests.user_factory import UserFactory
+
+
+@override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
+class ProjectGuardrailsConfigAPITestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.project = ProjectFactory()
+        self.project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
+        self.project.save(update_fields=["created_at"])
+        self.user = self.project.created_by
+        self.url = reverse("project-guardrails-config", kwargs={"project_uuid": str(self.project.uuid)})
+
+        self._patcher = mock.patch("nexus.projects.api.permissions.has_external_general_project_permission")
+        self._mock_ext_permission = self._patcher.start()
+
+        def _local_permission(request, project_uuid, method):
+            try:
+                project = Project.objects.get(uuid=project_uuid)
+                return has_project_permission(request.user, project, method)
+            except Project.DoesNotExist:
+                return False
+
+        self._mock_ext_permission.side_effect = _local_permission
+        self.client.force_authenticate(user=self.user)
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_get_lazy_init_new_project_blocks_all(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["writable"])
+        self.assertFalse(response.data["blocking_message_is_custom"])
+        self.assertTrue(response.data["blocking_message"])
+        self.assertEqual(len(response.data["categories"]), len(ProjectGuardrailsConfigUseCase.catalog_slugs()))
+        self.assertTrue(all(category["blocked"] for category in response.data["categories"]))
+        self.assertTrue(ProjectGuardrailsConfig.objects.filter(project=self.project).exists())
+
+    def test_get_lazy_init_existing_project_unblocks_all(self):
+        existing = ProjectFactory()
+        existing.created_at = django_timezone.make_aware(datetime(2025, 1, 1))
+        existing.save(update_fields=["created_at"])
+        self.client.force_authenticate(user=existing.created_by)
+        url = reverse("project-guardrails-config", kwargs={"project_uuid": str(existing.uuid)})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(any(category["blocked"] for category in response.data["categories"]))
+
+    def test_patch_block_category_without_confirmation(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+        ProjectGuardrailsConfig.objects.filter(project=self.project).update(
+            category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+        )
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": {"politics": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        politics = next(item for item in response.data["categories"] if item["slug"] == "politics")
+        self.assertTrue(politics["blocked"])
+
+    def test_patch_unblock_without_confirm_returns_409(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": {"politics": False}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertTrue(response.data["requires_confirmation"])
+        self.assertEqual(response.data["confirmation_type"], "disable_category")
+
+    def test_patch_unblock_with_confirm_persists(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": {"politics": False}, "confirm_disable": True},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        politics = next(item for item in response.data["categories"] if item["slug"] == "politics")
+        self.assertFalse(politics["blocked"])
+
+    def test_patch_unblock_all_requires_disable_all_confirmation(self):
+        config = ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+        all_unblocked = ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False)
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": all_unblocked},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.data["confirmation_type"], "disable_all")
+
+        confirmed = self.client.patch(
+            self.url,
+            {"category_states": all_unblocked, "confirm_disable": True},
+            format="json",
+        )
+        self.assertEqual(confirmed.status_code, status.HTTP_200_OK)
+        config.refresh_from_db()
+        self.assertFalse(any(config.category_states.values()))
+
+    def test_patch_blocking_message_success(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+
+        response = self.client.patch(
+            self.url,
+            {"blocking_message": "Custom refusal message"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["blocking_message_is_custom"])
+        self.assertEqual(response.data["blocking_message"], "Custom refusal message")
+
+    def test_patch_blocking_message_over_limit_returns_400(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+        too_long = "x" * (ProjectGuardrailsConfig.BLOCKING_MESSAGE_MAX_LENGTH + 1)
+
+        response = self.client.patch(
+            self.url,
+            {"blocking_message": too_long},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_denied_for_contributor(self):
+        contributor = UserFactory()
+        ProjectAuthFactory(
+            project=self.project,
+            user=contributor,
+            role=ProjectAuthorizationRole.CONTRIBUTOR.value,
+        )
+        self.client.force_authenticate(user=contributor)
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": {"politics": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_writable_false_for_contributor(self):
+        contributor = UserFactory()
+        ProjectAuthFactory(
+            project=self.project,
+            user=contributor,
+            role=ProjectAuthorizationRole.CONTRIBUTOR.value,
+        )
+        self.client.force_authenticate(user=contributor)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["writable"])
+
+    def test_get_unknown_project_denied_by_permission(self):
+        url = reverse(
+            "project-guardrails-config",
+            kwargs={"project_uuid": "00000000-0000-0000-0000-000000000000"},
+        )
+        response = self.client.get(url)
+        # Permission layer denies before the view can return 404.
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -809,9 +809,8 @@ class ProjectGuardrailsConfigView(APIView):
     permission_classes = [IsAuthenticated, GuardrailsConfigAdminPermission]
 
     def get(self, request, project_uuid):
-        try:
-            project = Project.objects.get(uuid=project_uuid)
-        except Project.DoesNotExist:
+        project = self._get_project(project_uuid)
+        if project is None:
             return Response({"detail": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
 
         config = ProjectGuardrailsConfigUseCase.get_or_initialize(project)
@@ -822,9 +821,8 @@ class ProjectGuardrailsConfigView(APIView):
         return Response(payload.as_dict(), status=status.HTTP_200_OK)
 
     def patch(self, request, project_uuid):
-        try:
-            project = Project.objects.get(uuid=project_uuid)
-        except Project.DoesNotExist:
+        project = self._get_project(project_uuid)
+        if project is None:
             return Response({"detail": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = GuardrailsConfigUpdateSerializer(data=request.data)
@@ -853,6 +851,13 @@ class ProjectGuardrailsConfigView(APIView):
 
         payload = ProjectGuardrailsConfigUseCase.to_payload(config, writable=True)
         return Response(payload.as_dict(), status=status.HTTP_200_OK)
+
+    @staticmethod
+    def _get_project(project_uuid):
+        try:
+            return Project.objects.get(uuid=project_uuid)
+        except Project.DoesNotExist:
+            return None
 
     @staticmethod
     def _is_writable(user, project: Project) -> bool:

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -21,10 +21,7 @@ from nexus.projects.exceptions import ProjectDoesNotExist
 from nexus.projects.models import Project, ProjectAuth
 from nexus.projects.permissions import get_user_auth, is_admin
 from nexus.projects.services.improvement_support_email import SendResult, send_improvement_support_ticket
-from nexus.usecases.guardrails.project_guardrails_config import (
-    GuardrailsConfirmationRequired,
-    ProjectGuardrailsConfigUseCase,
-)
+from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
 from nexus.usecases.projects.conversations import ConversationsUsecase
 from nexus.usecases.projects.dto import UpdateProjectDTO
 from nexus.usecases.projects.projects_use_case import ProjectsUseCase
@@ -835,16 +832,6 @@ class ProjectGuardrailsConfigView(APIView):
                 category_states=data.get("category_states"),
                 blocking_message=data.get("blocking_message"),
                 blocking_message_provided="blocking_message" in request.data,
-                confirm_disable=bool(data.get("confirm_disable", False)),
-            )
-        except GuardrailsConfirmationRequired as exc:
-            return Response(
-                {
-                    "requires_confirmation": True,
-                    "confirmation_type": exc.confirmation_type,
-                    "detail": exc.detail,
-                },
-                status=status.HTTP_409_CONFLICT,
             )
         except DjangoValidationError as exc:
             return Response(self._format_validation_error(exc), status=status.HTTP_400_BAD_REQUEST)

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -15,11 +15,16 @@ from rest_framework.views import APIView
 from inline_agents.backends.openai.backend import OpenAIBackend
 from nexus.agents.api.views import InternalCommunicationPermission
 from nexus.events import notify_async
-from nexus.projects.api.permissions import ProjectPermission
-from nexus.projects.api.serializers import ConversationSerializer
+from nexus.projects.api.permissions import GuardrailsConfigAdminPermission, ProjectPermission
+from nexus.projects.api.serializers import ConversationSerializer, GuardrailsConfigUpdateSerializer
 from nexus.projects.exceptions import ProjectDoesNotExist
-from nexus.projects.models import Project
+from nexus.projects.models import Project, ProjectAuth
+from nexus.projects.permissions import get_user_auth, is_admin
 from nexus.projects.services.improvement_support_email import SendResult, send_improvement_support_ticket
+from nexus.usecases.guardrails.project_guardrails_config import (
+    GuardrailsConfirmationRequired,
+    ProjectGuardrailsConfigUseCase,
+)
 from nexus.usecases.projects.conversations import ConversationsUsecase
 from nexus.usecases.projects.dto import UpdateProjectDTO
 from nexus.usecases.projects.projects_use_case import ProjectsUseCase
@@ -798,6 +803,72 @@ class ProjectApiErrorMessageView(APIView):
                 "error_message": _get_effective_api_error_message(project_uuid),
             }
         )
+
+
+class ProjectGuardrailsConfigView(APIView):
+    permission_classes = [IsAuthenticated, GuardrailsConfigAdminPermission]
+
+    def get(self, request, project_uuid):
+        try:
+            project = Project.objects.get(uuid=project_uuid)
+        except Project.DoesNotExist:
+            return Response({"detail": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        config = ProjectGuardrailsConfigUseCase.get_or_initialize(project)
+        payload = ProjectGuardrailsConfigUseCase.to_payload(
+            config,
+            writable=self._is_writable(request.user, project),
+        )
+        return Response(payload.as_dict(), status=status.HTTP_200_OK)
+
+    def patch(self, request, project_uuid):
+        try:
+            project = Project.objects.get(uuid=project_uuid)
+        except Project.DoesNotExist:
+            return Response({"detail": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = GuardrailsConfigUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        try:
+            config = ProjectGuardrailsConfigUseCase.update_config(
+                project,
+                category_states=data.get("category_states"),
+                blocking_message=data.get("blocking_message"),
+                blocking_message_provided="blocking_message" in request.data,
+                confirm_disable=bool(data.get("confirm_disable", False)),
+            )
+        except GuardrailsConfirmationRequired as exc:
+            return Response(
+                {
+                    "requires_confirmation": True,
+                    "confirmation_type": exc.confirmation_type,
+                    "detail": exc.detail,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        except DjangoValidationError as exc:
+            return Response(self._format_validation_error(exc), status=status.HTTP_400_BAD_REQUEST)
+
+        payload = ProjectGuardrailsConfigUseCase.to_payload(config, writable=True)
+        return Response(payload.as_dict(), status=status.HTTP_200_OK)
+
+    @staticmethod
+    def _is_writable(user, project: Project) -> bool:
+        try:
+            auth = get_user_auth(user, project)
+            return is_admin(auth)
+        except ProjectAuth.DoesNotExist:
+            return False
+
+    @staticmethod
+    def _format_validation_error(exc: DjangoValidationError) -> dict:
+        if hasattr(exc, "message_dict"):
+            return exc.message_dict
+        if hasattr(exc, "messages"):
+            return {"detail": list(exc.messages)}
+        return {"detail": [str(exc)]}
 
 
 class OpenSupportTicketView(APIView):

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -831,12 +831,15 @@ class ProjectGuardrailsConfigView(APIView):
                 project,
                 category_states=data.get("category_states"),
                 blocking_message=data.get("blocking_message"),
-                blocking_message_provided="blocking_message" in request.data,
+                blocking_message_provided="blocking_message" in serializer.validated_data,
             )
         except DjangoValidationError as exc:
             return Response(self._format_validation_error(exc), status=status.HTTP_400_BAD_REQUEST)
 
-        payload = ProjectGuardrailsConfigUseCase.to_payload(config, writable=True)
+        payload = ProjectGuardrailsConfigUseCase.to_payload(
+            config,
+            writable=self._is_writable(request.user, project),
+        )
         return Response(payload.as_dict(), status=status.HTTP_200_OK)
 
     @staticmethod

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -827,12 +827,10 @@ class ProjectGuardrailsConfigView(APIView):
         data = serializer.validated_data
 
         try:
-            config = ProjectGuardrailsConfigUseCase.update_config(
-                project,
-                category_states=data.get("category_states"),
-                blocking_message=data.get("blocking_message"),
-                blocking_message_provided="blocking_message" in serializer.validated_data,
-            )
+            update_kwargs = {"category_states": data.get("category_states")}
+            if "blocking_message" in data:
+                update_kwargs["blocking_message"] = data.get("blocking_message")
+            config = ProjectGuardrailsConfigUseCase.update_config(project, **update_kwargs)
         except DjangoValidationError as exc:
             return Response(self._format_validation_error(exc), status=status.HTTP_400_BAD_REQUEST)
 

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -9,13 +9,6 @@ from django.utils import timezone
 from nexus.projects.models import Project, ProjectGuardrailsConfig
 
 
-class GuardrailsConfirmationRequired(Exception):
-    def __init__(self, confirmation_type: str, detail: str | None = None):
-        self.confirmation_type = confirmation_type
-        self.detail = detail or "Confirmation required before unblocking guardrail categories."
-        super().__init__(self.detail)
-
-
 @dataclass(frozen=True)
 class GuardrailsConfigPayload:
     categories: list[dict]
@@ -178,18 +171,6 @@ class ProjectGuardrailsConfigUseCase:
         )
 
     @classmethod
-    def _unblocked_transitions(
-        cls,
-        previous_states: dict[str, bool],
-        next_states: dict[str, bool],
-    ) -> list[str]:
-        return [
-            slug
-            for slug in cls.catalog_slugs()
-            if previous_states.get(slug, False) and not next_states.get(slug, False)
-        ]
-
-    @classmethod
     def update_config(
         cls,
         project: Project,
@@ -197,7 +178,6 @@ class ProjectGuardrailsConfigUseCase:
         category_states: dict | None = None,
         blocking_message: str | None = None,
         blocking_message_provided: bool = False,
-        confirm_disable: bool = False,
     ) -> ProjectGuardrailsConfig:
         config = cls.get_or_initialize(project)
         previous_states = dict(config.category_states)
@@ -220,11 +200,6 @@ class ProjectGuardrailsConfigUseCase:
                 next_blocking_message = stripped if stripped else None
             else:
                 raise ValidationError({"blocking_message": "Blocking message must be a string or null."})
-
-        unblocked = cls._unblocked_transitions(previous_states, next_states)
-        if unblocked and not confirm_disable:
-            confirmation_type = "disable_all" if not cls.has_blocked_category(next_states) else "disable_category"
-            raise GuardrailsConfirmationRequired(confirmation_type=confirmation_type)
 
         cls.validate_blocking_message_for_states(next_blocking_message, next_states)
 

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -1,10 +1,35 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from nexus.projects.models import Project, ProjectGuardrailsConfig
+
+
+class GuardrailsConfirmationRequired(Exception):
+    def __init__(self, confirmation_type: str, detail: str | None = None):
+        self.confirmation_type = confirmation_type
+        self.detail = detail or "Confirmation required before unblocking guardrail categories."
+        super().__init__(self.detail)
+
+
+@dataclass(frozen=True)
+class GuardrailsConfigPayload:
+    categories: list[dict]
+    blocking_message: str
+    blocking_message_is_custom: bool
+    writable: bool
+
+    def as_dict(self) -> dict:
+        return {
+            "categories": self.categories,
+            "blocking_message": self.blocking_message,
+            "blocking_message_is_custom": self.blocking_message_is_custom,
+            "writable": self.writable,
+        }
 
 
 class ProjectGuardrailsConfigUseCase:
@@ -129,3 +154,89 @@ class ProjectGuardrailsConfigUseCase:
                 raise ValidationError({"category_states": f"Blocked state for '{slug}' must be a boolean."})
 
         return cls.sanitize_category_states(category_states)
+
+    @classmethod
+    def build_categories_response(cls, category_states: dict[str, bool]) -> list[dict]:
+        return [
+            {
+                "slug": entry["slug"],
+                "name": entry["name"],
+                "description": entry["description"],
+                "blocked": bool(category_states.get(entry["slug"], False)),
+            }
+            for entry in cls.catalog()
+        ]
+
+    @classmethod
+    def to_payload(cls, config: ProjectGuardrailsConfig, *, writable: bool) -> GuardrailsConfigPayload:
+        message, is_custom = cls.effective_blocking_message(config)
+        return GuardrailsConfigPayload(
+            categories=cls.build_categories_response(config.category_states),
+            blocking_message=message,
+            blocking_message_is_custom=is_custom,
+            writable=writable,
+        )
+
+    @classmethod
+    def _unblocked_transitions(
+        cls,
+        previous_states: dict[str, bool],
+        next_states: dict[str, bool],
+    ) -> list[str]:
+        return [
+            slug
+            for slug in cls.catalog_slugs()
+            if previous_states.get(slug, False) and not next_states.get(slug, False)
+        ]
+
+    @classmethod
+    def update_config(
+        cls,
+        project: Project,
+        *,
+        category_states: dict | None = None,
+        blocking_message: str | None = None,
+        blocking_message_provided: bool = False,
+        confirm_disable: bool = False,
+    ) -> ProjectGuardrailsConfig:
+        config = cls.get_or_initialize(project)
+        previous_states = dict(config.category_states)
+        next_states = dict(previous_states)
+
+        if category_states is not None:
+            validated_partial = cls.validate_category_states(category_states)
+            next_states.update(validated_partial)
+            next_states = cls.merge_category_states(
+                next_states,
+                default_blocked=config.initialized_as_new_project,
+            )
+
+        next_blocking_message = config.blocking_message
+        if blocking_message_provided:
+            if blocking_message is None:
+                next_blocking_message = None
+            elif isinstance(blocking_message, str):
+                stripped = blocking_message.strip()
+                next_blocking_message = stripped if stripped else None
+            else:
+                raise ValidationError({"blocking_message": "Blocking message must be a string or null."})
+
+        unblocked = cls._unblocked_transitions(previous_states, next_states)
+        if unblocked and not confirm_disable:
+            confirmation_type = "disable_all" if not cls.has_blocked_category(next_states) else "disable_category"
+            raise GuardrailsConfirmationRequired(confirmation_type=confirmation_type)
+
+        cls.validate_blocking_message_for_states(next_blocking_message, next_states)
+
+        update_fields: list[str] = ["modified_on"]
+        if next_states != config.category_states:
+            config.category_states = next_states
+            update_fields.append("category_states")
+        if blocking_message_provided and next_blocking_message != config.blocking_message:
+            config.blocking_message = next_blocking_message
+            update_fields.append("blocking_message")
+
+        if len(update_fields) > 1:
+            config.save(update_fields=update_fields)
+
+        return config

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -228,15 +228,17 @@ class ProjectGuardrailsConfigUseCase:
 
         cls.validate_blocking_message_for_states(next_blocking_message, next_states)
 
-        update_fields: list[str] = ["modified_on"]
-        if next_states != config.category_states:
-            config.category_states = next_states
-            update_fields.append("category_states")
-        if blocking_message_provided and next_blocking_message != config.blocking_message:
-            config.blocking_message = next_blocking_message
-            update_fields.append("blocking_message")
+        category_states_changed = next_states != config.category_states
+        blocking_message_changed = blocking_message_provided and next_blocking_message != config.blocking_message
 
-        if len(update_fields) > 1:
+        if category_states_changed or blocking_message_changed:
+            update_fields = ["modified_on"]
+            if category_states_changed:
+                config.category_states = next_states
+                update_fields.append("category_states")
+            if blocking_message_changed:
+                config.blocking_message = next_blocking_message
+                update_fields.append("blocking_message")
             config.save(update_fields=update_fields)
 
         return config

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -153,8 +153,6 @@ class ProjectGuardrailsConfigUseCase:
         return [
             {
                 "slug": entry["slug"],
-                "name": entry["name"],
-                "description": entry["description"],
                 "blocked": bool(category_states.get(entry["slug"], False)),
             }
             for entry in cls.catalog()

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -8,6 +8,8 @@ from django.utils import timezone
 
 from nexus.projects.models import Project, ProjectGuardrailsConfig
 
+_UNSET = object()
+
 
 @dataclass(frozen=True)
 class GuardrailsConfigPayload:
@@ -174,8 +176,7 @@ class ProjectGuardrailsConfigUseCase:
         project: Project,
         *,
         category_states: dict | None = None,
-        blocking_message: str | None = None,
-        blocking_message_provided: bool = False,
+        blocking_message: str | None = _UNSET,
     ) -> ProjectGuardrailsConfig:
         config = cls.get_or_initialize(project)
         previous_states = dict(config.category_states)
@@ -190,7 +191,7 @@ class ProjectGuardrailsConfigUseCase:
             )
 
         next_blocking_message = config.blocking_message
-        if blocking_message_provided:
+        if blocking_message is not _UNSET:
             if blocking_message is None:
                 next_blocking_message = None
             elif isinstance(blocking_message, str):
@@ -202,7 +203,7 @@ class ProjectGuardrailsConfigUseCase:
         cls.validate_blocking_message_for_states(next_blocking_message, next_states)
 
         category_states_changed = next_states != config.category_states
-        blocking_message_changed = blocking_message_provided and next_blocking_message != config.blocking_message
+        blocking_message_changed = blocking_message is not _UNSET and next_blocking_message != config.blocking_message
 
         if category_states_changed or blocking_message_changed:
             update_fields = ["modified_on"]

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -8,10 +8,7 @@ from rest_framework.request import Request
 
 from nexus.projects.api.permissions import GuardrailsConfigAdminPermission
 from nexus.projects.models import ProjectAuthorizationRole, ProjectGuardrailsConfig
-from nexus.usecases.guardrails.project_guardrails_config import (
-    GuardrailsConfirmationRequired,
-    ProjectGuardrailsConfigUseCase,
-)
+from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
 from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
 
@@ -112,22 +109,7 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertTrue(is_custom)
         self.assertEqual(message, "Custom refusal")
 
-    def test_update_requires_confirmation_when_unblocking(self):
-        project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        project.save(update_fields=["created_at"])
-        self.use_case.get_or_initialize(project)
-
-        with self.assertRaises(GuardrailsConfirmationRequired) as ctx:
-            self.use_case.update_config(
-                project,
-                category_states={"politics": False},
-                confirm_disable=False,
-            )
-
-        self.assertEqual(ctx.exception.confirmation_type, "disable_category")
-
-    def test_update_with_confirm_disable_persists_unblock(self):
+    def test_update_unblocks_without_confirmation(self):
         project = ProjectFactory()
         project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
         project.save(update_fields=["created_at"])
@@ -136,12 +118,11 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         config = self.use_case.update_config(
             project,
             category_states={"politics": False},
-            confirm_disable=True,
         )
 
         self.assertFalse(config.category_states["politics"])
 
-    def test_update_message_only_does_not_require_confirmation(self):
+    def test_update_message_only_leaves_category_states(self):
         project = ProjectFactory()
         config = self.use_case.get_or_initialize(project)
 

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -8,7 +8,10 @@ from rest_framework.request import Request
 
 from nexus.projects.api.permissions import GuardrailsConfigAdminPermission
 from nexus.projects.models import ProjectAuthorizationRole, ProjectGuardrailsConfig
-from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
+from nexus.usecases.guardrails.project_guardrails_config import (
+    GuardrailsConfirmationRequired,
+    ProjectGuardrailsConfigUseCase,
+)
 from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
 
@@ -108,6 +111,48 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
 
         self.assertTrue(is_custom)
         self.assertEqual(message, "Custom refusal")
+
+    def test_update_requires_confirmation_when_unblocking(self):
+        project = ProjectFactory()
+        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
+        project.save(update_fields=["created_at"])
+        self.use_case.get_or_initialize(project)
+
+        with self.assertRaises(GuardrailsConfirmationRequired) as ctx:
+            self.use_case.update_config(
+                project,
+                category_states={"politics": False},
+                confirm_disable=False,
+            )
+
+        self.assertEqual(ctx.exception.confirmation_type, "disable_category")
+
+    def test_update_with_confirm_disable_persists_unblock(self):
+        project = ProjectFactory()
+        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
+        project.save(update_fields=["created_at"])
+        self.use_case.get_or_initialize(project)
+
+        config = self.use_case.update_config(
+            project,
+            category_states={"politics": False},
+            confirm_disable=True,
+        )
+
+        self.assertFalse(config.category_states["politics"])
+
+    def test_update_message_only_does_not_require_confirmation(self):
+        project = ProjectFactory()
+        config = self.use_case.get_or_initialize(project)
+
+        updated = self.use_case.update_config(
+            project,
+            blocking_message="Brand refusal",
+            blocking_message_provided=True,
+        )
+
+        self.assertEqual(updated.blocking_message, "Brand refusal")
+        self.assertEqual(updated.category_states, config.category_states)
 
 
 class GuardrailsConfigAdminPermissionTestCase(TestCase):

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -129,7 +129,6 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         updated = self.use_case.update_config(
             project,
             blocking_message="Brand refusal",
-            blocking_message_provided=True,
         )
 
         self.assertEqual(updated.blocking_message, "Brand refusal")

--- a/specs/001-project-guardrails-config/checklists/requirements.md
+++ b/specs/001-project-guardrails-config/checklists/requirements.md
@@ -25,7 +25,8 @@
 
 ## Notes
 
-- 2026-07-06: Rewritten for strict backend scope; confirmation is API contract (`409` / `confirm_disable`), not UI.
+- 2026-07-06: Rewritten for strict backend scope; confirmation was initially API contract (`409` / `confirm_disable`).
 - 2026-07-06 clarify: 5 questions resolved (admin role, new/existing default, default message, PATCH confirmation, catalog merge).
+- 2026-07-20: Confirmation moved to frontend-only (FDD modal); backend persists unblock immediately — no `confirm_disable` / `409`.
 - 2026-07-06 clarify (naming): *topic* → **guardrail category**; *topic_states* → **category_states**; backend i18n out of scope (T002 dropped).
 - 2026-07-16: Runtime redesigned — `ApplyGuardrail` in Nexus preprocess (INPUT only), one Bedrock guardrail per project, omit unblocked categories on sync, blocking message Option A (Nexus message, ignore Bedrock canned text). Replaced payload/`categories` map for Models + Lambda path.

--- a/specs/001-project-guardrails-config/contracts/guardrails-config-api.yaml
+++ b/specs/001-project-guardrails-config/contracts/guardrails-config-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Project Guardrails Configuration API
-  version: 1.1.0
+  version: 1.2.0
   description: Nexus backend — guardrail category block states and blocking message
 
 paths:
@@ -45,11 +45,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GuardrailsConfigResponse"
-        "409":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ConfirmationRequired"
 
 components:
   schemas:
@@ -64,7 +59,7 @@ components:
           description: English catalog label from settings
         description:
           type: string
-          description: English catalog description from settings
+          description: English scope description from settings
         blocked:
           type: boolean
 
@@ -98,17 +93,3 @@ components:
           type: string
           maxLength: 240
           nullable: true
-        confirm_disable:
-          type: boolean
-          default: false
-
-    ConfirmationRequired:
-      type: object
-      properties:
-        requires_confirmation:
-          type: boolean
-        confirmation_type:
-          type: string
-          enum: [disable_category, disable_all]
-        detail:
-          type: string

--- a/specs/001-project-guardrails-config/contracts/guardrails-config-api.yaml
+++ b/specs/001-project-guardrails-config/contracts/guardrails-config-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Project Guardrails Configuration API
-  version: 1.2.0
+  version: 1.3.0
   description: Nexus backend — guardrail category block states and blocking message
 
 paths:
@@ -50,16 +50,11 @@ components:
   schemas:
     GuardrailCategory:
       type: object
-      required: [slug, name, description, blocked]
+      required: [slug, blocked]
       properties:
         slug:
           type: string
-        name:
-          type: string
-          description: English catalog label from settings
-        description:
-          type: string
-          description: English scope description from settings
+          description: Stable catalog key; display name/description come from frontend i18n
         blocked:
           type: boolean
 

--- a/specs/001-project-guardrails-config/data-model.md
+++ b/specs/001-project-guardrails-config/data-model.md
@@ -49,7 +49,7 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 ## State Transitions
 
 ```
-blocked --PATCH + confirm_disable--> unblocked --> Bedrock sync (omit category)
+blocked --PATCH--> unblocked --> Bedrock sync (omit category)
 unblocked --PATCH--> blocked --> Bedrock sync (include category)
 
 (no row) --first GET--> lazy init --> row [--> create/sync Bedrock when any blocked]

--- a/specs/001-project-guardrails-config/data-model.md
+++ b/specs/001-project-guardrails-config/data-model.md
@@ -9,8 +9,8 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 | Field | Type | Notes |
 |-------|------|-------|
 | slug | string | Stable key, e.g. `politics`, `physical_health` |
-| name | string | English display label (API response) |
-| description | string | English scope description (API response) |
+| name | string | English label in settings (Bedrock/docs; **not** returned by API) |
+| description | string | English scope in settings (Bedrock/docs; **not** returned by API) |
 | bedrock_definition | string | Denied topic definition for Bedrock sync (may equal description) |
 | bedrock_examples | string[] | Optional sample phrases for Bedrock (max 5) |
 

--- a/specs/001-project-guardrails-config/plan.md
+++ b/specs/001-project-guardrails-config/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, confirmation contract (`disable_category` / `disable_all`), **one Bedrock Guardrail per project** synced with only blocked categories, **`ApplyGuardrail` on INPUT** in existing preprocess (Option A message resolution), cache invalidation. No backend i18n. No Lambda for this flow.
+Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, immediate unblock (confirmation UX is frontend-only), **one Bedrock Guardrail per project** synced with only blocked categories, **`ApplyGuardrail` on INPUT** in existing preprocess (Option A message resolution), cache invalidation. No backend i18n. No Lambda for this flow.
 
 ## Technical Context
 

--- a/specs/001-project-guardrails-config/quickstart.md
+++ b/specs/001-project-guardrails-config/quickstart.md
@@ -3,42 +3,32 @@
 ```bash
 # 1. GET (lazy init)
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+  "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 2. Block a category (persists + syncs Bedrock Denied Topics subset)
+# 2. Block a category
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"category_states": {"politics": true}}' \
-  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+  "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 3. Unblock without confirm → 409
+# 3. Unblock a category (persists immediately; FE may show a modal before this call)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"category_states": {"politics": false}}' \
-  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+  "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 4. Unblock with confirm (sync omits category from Bedrock)
-curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"category_states": {"politics": false}, "confirm_disable": true}' \
-  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
-
-# 5. Message-only PATCH (no Bedrock version bump)
+# 4. Message-only PATCH
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"blocking_message": "I cannot help with that request."}' \
-  "http://localhost:8000/api/v1/projects/$PROJECT_UUID/guardrails-config/" | jq
+  "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 6. Inspect persisted Bedrock ids + effective message
+# 5. Inspect persisted config
 python manage.py shell -c "
 from nexus.projects.models import ProjectGuardrailsConfig
 c = ProjectGuardrailsConfig.objects.get(project__uuid='$PROJECT_UUID')
-print(c.bedrock_guardrail_identifier, c.bedrock_guardrail_version, c.blocking_message)
+print(c.category_states, c.blocking_message)
 "
 
-# 7. Runtime: send a user message that hits a blocked category and confirm
-#    the reply is the project message (Option A), not Bedrock canned text.
-#    Ensure preprocess does not call GUARDRAILS_LAYER_LAMBDA.
-
-pytest nexus/projects/api/tests/test_guardrails_config.py nexus/usecases/guardrails/tests/ router/tasks/tests/ -q -k guardrail
+pytest nexus/projects/api/tests/test_guardrails_config.py nexus/usecases/guardrails/tests/ -q -k guardrail
 ```

--- a/specs/001-project-guardrails-config/research.md
+++ b/specs/001-project-guardrails-config/research.md
@@ -29,9 +29,9 @@
 
 ---
 
-## R3 — Admin writes, lazy init, confirmation
+## R3 — Admin writes, lazy init, unblock
 
-**Decision**: Moderator/org-admin PATCH only; `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` + lazy init on first GET; `confirm_disable` contract (`disable_category` | `disable_all`); cache invalidation on PATCH.
+**Decision**: Moderator/org-admin PATCH only; `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` + lazy init on first GET; unblock persists immediately (confirmation UX is frontend-only); cache invalidation on PATCH.
 
 Unchanged from 2026-07-06 product/API clarifications.
 

--- a/specs/001-project-guardrails-config/research.md
+++ b/specs/001-project-guardrails-config/research.md
@@ -18,12 +18,12 @@
 
 **Decision**: **No i18n layer in Nexus for this feature.**
 
-- Catalog `name`/`description`: English strings in settings constant.
+- Catalog `name`/`description`: English strings may remain in settings for Bedrock sync/docs; **API does not return them** — frontend i18n keys by `slug`.
 - Default blocking message: `settings.GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` (single string).
 - Custom blocking message: stored as submitted.
 - Remove `Accept-Language` from admin API contract.
 
-**Rationale**: Label localization is a presentation concern for API consumers outside this backend scope.
+**Rationale**: Label localization is a presentation concern owned by the frontend.
 
 **Rejected**: locale module task — frontend/i18n pipeline pattern, not Nexus backend responsibility.
 

--- a/specs/001-project-guardrails-config/spec.md
+++ b/specs/001-project-guardrails-config/spec.md
@@ -19,7 +19,7 @@
 - Q: Who may write guardrails configuration via API? → A: Project **moderator** or **organization admin** only.
 - Q: New vs existing project defaults? → A: `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` + lazy init on first GET.
 - Q: Default blocking message? → A: `settings.GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` until custom message is saved; custom stored verbatim, no auto-translation.
-- Q: PATCH confirmation? → A: `confirm_disable: true` required when unblocking categories; `disable_all` when all unblocked.
+- Q: PATCH confirmation? → A: **Frontend-only** (FDD modal). Backend persists unblock immediately; no `confirm_disable` / `409` handshake.
 - Q: New catalog entries? → A: Merge on GET; missing slugs inherit project-type default.
 
 ### Session 2026-07-06
@@ -41,16 +41,15 @@
 
 As an authenticated admin API consumer, I need to read and update per-category blocked states for a project so guardrail behavior can be controlled without engineering intervention.
 
-**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked with confirmation, verify Bedrock sync omits the unblocked category and the next input no longer blocks that category.
+**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked, verify Bedrock sync omits the unblocked category and the next input no longer blocks that category.
 
 **Acceptance Scenarios**:
 
 1. **Given** valid project UUID and auth, **When** `GET /guardrails-config/`, **Then** response lists all fixed catalog categories with `slug`, `name`, `description`, and `blocked`.
-2. **Given** category blocked, **When** PATCH unblocks without `confirm_disable`, **Then** `409` with `confirmation_type: disable_category`.
-3. **Given** PATCH unblock with `confirm_disable: true`, **Then** persists, syncs Bedrock guardrail without that category, and runtime no longer blocks it.
-4. **Given** category unblocked, **When** PATCH blocks without confirmation, **Then** persists immediately and syncs Bedrock including that category.
-5. **Given** PATCH unblocks all categories without `confirm_disable`, **Then** `409` with `confirmation_type: disable_all`.
-6. **Given** PATCH unblocks all with `confirm_disable: true`, **Then** all categories unblocked and Bedrock sync reflects no denied categories (runtime skips `ApplyGuardrail` or never intervenes).
+2. **Given** category blocked, **When** PATCH unblocks it, **Then** persists immediately, syncs Bedrock guardrail without that category, and runtime no longer blocks it.
+3. **Given** category unblocked, **When** PATCH blocks it, **Then** persists immediately and syncs Bedrock including that category.
+4. **Given** PATCH unblocks all categories, **Then** all categories unblocked and Bedrock sync reflects no denied categories (runtime skips `ApplyGuardrail` or never intervenes).
+5. **Given** operator wants UX confirmation before unblocking, **When** Agent Builder shows a modal, **Then** FE calls PATCH once after confirm (backend does not enforce a two-step handshake).
 
 ---
 
@@ -106,9 +105,9 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 - **FR-006**: Reject blocking messages >240 characters.
 - **FR-007**: Reject empty/whitespace blocking message when any category blocked.
 - **FR-008**: Lazy init defaults all categories blocked (new) or unblocked (existing).
-- **FR-009**: PATCH unblocking categories requires `confirm_disable: true` or returns `409`.
-- **FR-010**: PATCH unblocking all categories returns `409` with `disable_all` unless confirmed.
-- **FR-011**: PATCH blocking categories does NOT require confirmation.
+- **FR-009**: PATCH unblocking categories persists immediately (confirmation UX is frontend-only).
+- **FR-010**: PATCH may unblock all categories in one request.
+- **FR-011**: PATCH blocking and unblocking categories use the same request shape (`category_states`).
 - **FR-012**: Runtime MUST evaluate each user input with Bedrock `ApplyGuardrail` (`source=INPUT`) using the project's guardrail identifier/version **before** agent processing, reusing the existing preprocess/`invoke` path (no dedicated OpenAI-only pipeline; no `GUARDRAILS_LAYER_LAMBDA` for this flow).
 - **FR-013**: Changes apply only to messages after successful PATCH (and successful Bedrock sync when categories change).
 - **FR-014**: GET merges new catalog slugs with project-type defaults.
@@ -136,7 +135,7 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 - **SC-003**: After category PATCH + Bedrock sync, the next user input is evaluated with the updated denied-topic set; on intervene, customer receives the project effective message (Option A).
 - **SC-004**: 100% of non-admin PATCH return `403`.
 - **SC-005**: First GET: new projects all blocked; existing all unblocked.
-- **SC-006**: 100% of unconfirmed disable PATCH return `409` with typed metadata.
+- **SC-006**: Unblock PATCH persists immediately without a backend confirmation handshake.
 - **SC-007**: Preprocess guardrail path does not invoke `GUARDRAILS_LAYER_LAMBDA` for this feature.
 
 ## Assumptions

--- a/specs/001-project-guardrails-config/spec.md
+++ b/specs/001-project-guardrails-config/spec.md
@@ -25,7 +25,7 @@
 ### Session 2026-07-06
 
 - Q: Rename away from *topic*? → A: **guardrail category** / `category_states` / `GUARDRAIL_CATEGORY_CATALOG`. Rejects *instruction* (conflicts with existing Instructions domain) and *topic* (conflicts with conversation Topics).
-- Q: Backend i18n for catalog labels? → A: **Out of scope.** API returns English `name`/`description` from code constant. No `Accept-Language`, no locale module. Default blocking message is a single settings string.
+- Q: Backend i18n for catalog labels? → A: **Out of scope.** API returns only `slug` + `blocked`; frontend owns `name`/`description` via translation files keyed by slug. No `Accept-Language`, no locale module. Default blocking message is a single settings string.
 
 ### Session 2026-07-16
 
@@ -45,7 +45,7 @@ As an authenticated admin API consumer, I need to read and update per-category b
 
 **Acceptance Scenarios**:
 
-1. **Given** valid project UUID and auth, **When** `GET /guardrails-config/`, **Then** response lists all fixed catalog categories with `slug`, `name`, `description`, and `blocked`.
+1. **Given** valid project UUID and auth, **When** `GET /guardrails-config/`, **Then** response lists all fixed catalog categories with `slug` and `blocked` (no `name`/`description`).
 2. **Given** category blocked, **When** PATCH unblocks it, **Then** persists immediately, syncs Bedrock guardrail without that category, and runtime no longer blocks it.
 3. **Given** category unblocked, **When** PATCH blocks it, **Then** persists immediately and syncs Bedrock including that category.
 4. **Given** PATCH unblocks all categories, **Then** all categories unblocked and Bedrock sync reflects no denied categories (runtime skips `ApplyGuardrail` or never intervenes).
@@ -97,7 +97,7 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 
 ### Functional Requirements
 
-- **FR-001**: API MUST expose GET/PATCH with full fixed **guardrail category** catalog (`slug`, `name`, `description`, `blocked`).
+- **FR-001**: API MUST expose GET/PATCH with full fixed **guardrail category** catalog (`slug`, `blocked`). Display labels are frontend-owned.
 - **FR-002**: `blocked: true` = category refused; `blocked: false` = allowed.
 - **FR-003**: PATCH persists `category_states` at project level for admin only.
 - **FR-004**: PATCH returns `403` for non-admin.
@@ -125,7 +125,7 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 
 ### Key Entities
 
-- **Guardrail category (catalog entry)**: Platform slug + English label/description (+ Bedrock denied-topic definition/examples as needed); not mutable via API.
+- **Guardrail category (catalog entry)**: Platform slug (+ Bedrock denied-topic definition/examples as needed); display name/description are frontend i18n; not mutable via API.
 - **Project guardrails configuration**: One-to-one with project; `category_states` + optional custom blocking message + Bedrock guardrail identifier/version.
 
 ## Success Criteria *(mandatory)*
@@ -141,7 +141,7 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 ## Assumptions
 
 - Conversation **Topics** (`Topics` model, lambda classifier) are a separate domain — no shared tables or APIs.
-- Catalog labels in API are **English strings** from `GUARDRAIL_CATEGORY_CATALOG` (display localization is out of backend scope).
+- Catalog display labels are frontend-owned (i18n by `slug`); API returns only `slug` + `blocked`.
 - Bedrock Denied Topics are the enforcement mechanism; Nexus owns sync + `ApplyGuardrail` + customer-facing message resolution.
 - Fail-open vs fail-closed on Bedrock API errors during preprocess is an implementation decision to document in research/plan and cover with tests.
 

--- a/specs/001-project-guardrails-config/tasks.md
+++ b/specs/001-project-guardrails-config/tasks.md
@@ -18,7 +18,7 @@
 - [ ] T006 [US1] Serializers in `nexus/projects/api/serializers.py` (`categories` in response, `category_states` in PATCH)
 - [ ] T007 [US1] `ProjectGuardrailsConfigView` GET/PATCH in `nexus/projects/api/views.py`
 - [ ] T008 [US1] Route in `nexus/projects/api/routers.py`
-- [ ] T009 [US1] Confirmation logic (`409`, `disable_category`, `disable_all`) in use case
+- [x] T009 [US1] Unblock persists immediately (no backend confirmation handshake)
 - [ ] T010 [P] [US1] Tests in `nexus/projects/api/tests/test_guardrails_config.py`
 
 ## Phase 4: User Story 2 — Blocking message (P2)


### PR DESCRIPTION
## Summary

- Add `GET/PATCH /api/<project_uuid>/guardrails-config/` endpoint for reading and partially updating per-project guardrail categories and blocking message.
- Extend `ProjectGuardrailsConfigUseCase` with `to_payload`, `update_config`, and `build_categories_response` methods, plus a `GuardrailsConfigPayload` dataclass; unblocking categories now persists immediately with no backend confirmation handshake (`confirm_disable` / `409` flow removed — confirmation UX is frontend-only).
- Add `GuardrailsConfigUpdateSerializer` and `GuardrailsConfigResponseSerializer` for request validation and response shaping, enforcing `BLOCKING_MESSAGE_MAX_LENGTH` and requiring at least one of `category_states` or `blocking_message`.
- API response now returns only `slug` and `blocked` per category; `name` and `description` are dropped from the response contract and are frontend i18n concerns keyed by slug.
- Cover API and use-case flows for lazy init, block/unblock, blocking message updates, over-limit message rejection, and admin vs contributor permission enforcement.
- Update spec, contract (v1.3.0), data model, plan, research, and quickstart to reflect the removal of the `409`/`confirm_disable` handshake and the frontend-owned display label decision.