### PR TITLE
feat: place progressive feedback instruction at end when use_components is enabled

### DIFF
--- a/inline_agents/backends/openai/adapter.py
+++ b/inline_agents/backends/openai/adapter.py
@@ -1163,8 +1163,8 @@ class OpenAITeamAdapter(TeamAdapter):
         rendered_content = template.render(context_object)
 
         from inline_agents.backends.openai.prompts_progressive_feedback import (
+            apply_progressive_feedback_instruction,
             get_progressive_feedback_orchestration_instruction,
-            inject_progressive_feedback_instruction,
             log_progressive_feedback_orchestration_decision,
             should_inject_progressive_feedback_instruction,
         )
@@ -1179,9 +1179,10 @@ class OpenAITeamAdapter(TeamAdapter):
         ):
             progressive_feedback_instruction = get_progressive_feedback_orchestration_instruction()
             if progressive_feedback_instruction:
-                rendered_content = inject_progressive_feedback_instruction(
+                rendered_content = apply_progressive_feedback_instruction(
                     rendered_content,
                     progressive_feedback_instruction,
+                    use_components=use_components,
                 )
                 log_progressive_feedback_orchestration_decision(
                     project_id=project_id,
@@ -1193,6 +1194,7 @@ class OpenAITeamAdapter(TeamAdapter):
                     turn_off_rationale=turn_off_rationale,
                     injected=True,
                     instruction_preview=progressive_feedback_instruction[:120],
+                    placement="end" if use_components else "core_identity",
                 )
             else:
                 log_progressive_feedback_orchestration_decision(

--- a/inline_agents/backends/openai/prompts_progressive_feedback.py
+++ b/inline_agents/backends/openai/prompts_progressive_feedback.py
@@ -51,6 +51,7 @@ def find_core_identity_marker(prompt: str) -> str | None:
 
 
 def inject_progressive_feedback_instruction(rendered_prompt: str, instruction: str) -> str:
+    """Insert PF instruction before core identity (used when use_components is False)."""
     instruction = instruction.strip()
     if not instruction:
         return rendered_prompt
@@ -67,6 +68,30 @@ def inject_progressive_feedback_instruction(rendered_prompt: str, instruction: s
     return f"{instruction}\n\n{rendered_prompt}"
 
 
+def append_progressive_feedback_instruction_at_end(rendered_prompt: str, instruction: str) -> str:
+    """Append PF instruction at the end of the system prompt (used when use_components is True)."""
+    instruction = instruction.strip()
+    if not instruction:
+        return rendered_prompt
+
+    base = (rendered_prompt or "").rstrip()
+    if not base:
+        return instruction
+    return f"{base}\n\n## Progressive feedback\n{instruction}"
+
+
+def apply_progressive_feedback_instruction(
+    rendered_prompt: str,
+    instruction: str,
+    *,
+    use_components: bool,
+) -> str:
+    """Place PF instruction: end of prompt when components are on, else before core identity."""
+    if use_components:
+        return append_progressive_feedback_instruction_at_end(rendered_prompt, instruction)
+    return inject_progressive_feedback_instruction(rendered_prompt, instruction)
+
+
 def log_progressive_feedback_orchestration_decision(
     *,
     project_id: str,
@@ -78,15 +103,17 @@ def log_progressive_feedback_orchestration_decision(
     preview: bool = False,
     preview_websocket: bool = False,
     instruction_preview: str | None = None,
+    placement: str | None = None,
 ) -> None:
     channel_from_urn = channel_hint_from_contact_urn(contact_urn) if contact_urn else None
     if injected:
         logger.info(
             "[ProgressiveFeedback] Orchestration instruction injected project_id=%s channel_from_urn=%s "
-            "contact_urn=%s instruction_preview=%r",
+            "contact_urn=%s placement=%s instruction_preview=%r",
             project_id,
             channel_from_urn,
             contact_urn or None,
+            placement or "core_identity",
             instruction_preview,
         )
         return

--- a/inline_agents/backends/openai/tests/test_prompts_progressive_feedback.py
+++ b/inline_agents/backends/openai/tests/test_prompts_progressive_feedback.py
@@ -3,6 +3,8 @@ from django.test import SimpleTestCase, override_settings
 from inline_agents.backends.openai.adapter import OpenAITeamAdapter
 from inline_agents.backends.openai.prompts_progressive_feedback import (
     DEFAULT_PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION,
+    append_progressive_feedback_instruction_at_end,
+    apply_progressive_feedback_instruction,
     find_core_identity_marker,
     inject_progressive_feedback_instruction,
     should_inject_progressive_feedback_instruction,
@@ -133,6 +135,42 @@ class TestInjectProgressiveFeedbackInstruction(SimpleTestCase):
         )
 
 
+class TestAppendProgressiveFeedbackInstructionAtEnd(SimpleTestCase):
+    def test_appends_section_at_end(self):
+        result = append_progressive_feedback_instruction_at_end(CORE_IDENTITY_XML_PROMPT, TEST_INSTRUCTION)
+
+        self.assertTrue(result.endswith(f"## Progressive feedback\n{TEST_INSTRUCTION}"))
+        self.assertGreater(result.index("## Progressive feedback"), result.index("</core_identity>"))
+
+    def test_returns_unchanged_when_instruction_empty(self):
+        self.assertEqual(
+            append_progressive_feedback_instruction_at_end(CORE_IDENTITY_XML_PROMPT, ""),
+            CORE_IDENTITY_XML_PROMPT,
+        )
+
+
+class TestApplyProgressiveFeedbackInstruction(SimpleTestCase):
+    def test_uses_core_identity_when_components_disabled(self):
+        result = apply_progressive_feedback_instruction(
+            CORE_IDENTITY_XML_PROMPT,
+            TEST_INSTRUCTION,
+            use_components=False,
+        )
+
+        self.assertLess(result.index(TEST_INSTRUCTION), result.index("<core_identity>"))
+        self.assertNotIn("## Progressive feedback", result)
+
+    def test_uses_end_placement_when_components_enabled(self):
+        result = apply_progressive_feedback_instruction(
+            CORE_IDENTITY_XML_PROMPT,
+            TEST_INSTRUCTION,
+            use_components=True,
+        )
+
+        self.assertTrue(result.endswith(f"## Progressive feedback\n{TEST_INSTRUCTION}"))
+        self.assertGreater(result.index(TEST_INSTRUCTION), result.index("</core_identity>"))
+
+
 class TestGetSupervisorInstructionsProgressiveFeedback(SimpleTestCase):
     def _call_get_supervisor_instructions(self, **overrides):
         defaults = {
@@ -223,3 +261,26 @@ class TestGetSupervisorInstructionsProgressiveFeedback(SimpleTestCase):
         )
 
         self.assertTrue(result.startswith(f"{TEST_INSTRUCTION}\n\n# Manager"))
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_appends_at_end_when_use_components_enabled(self):
+        result = self._call_get_supervisor_instructions(
+            rationale_switch=True,
+            use_components=True,
+            components_instructions="Use quick replies when needed.",
+        )
+
+        self.assertIn(TEST_INSTRUCTION, result)
+        self.assertTrue(result.rstrip().endswith(TEST_INSTRUCTION))
+        self.assertIn("## Progressive feedback", result)
+        self.assertGreater(result.index("## Progressive feedback"), result.index("<core_identity>"))
+
+    @override_settings(PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION=TEST_INSTRUCTION)
+    def test_keeps_core_identity_inject_when_use_components_disabled(self):
+        result = self._call_get_supervisor_instructions(
+            rationale_switch=True,
+            use_components=False,
+        )
+
+        self.assertLess(result.index(TEST_INSTRUCTION), result.index("<core_identity>"))
+        self.assertNotIn("## Progressive feedback", result)


### PR DESCRIPTION
- Replaced `inject_progressive_feedback_instruction` with `apply_progressive_feedback_instruction` in the adapter, which routes placement logic based on the `use_components` flag — appending at the end when components are enabled, or inserting before `core_identity` when they are not.
- Introduced `append_progressive_feedback_instruction_at_end` to append the progressive feedback instruction under a `## Progressive feedback` heading at the end of the system prompt when `use_components=True`.
- Updated `log_progressive_feedback_orchestration_decision` to accept and log a `placement` field, recording whether the instruction was placed at `"end"` or `"core_identity"`.
- Added unit tests for `append_progressive_feedback_instruction_at_end` and `apply_progressive_feedback_instruction`, and extended integration-level tests to verify correct placement behavior for both `use_components=True` and `use_components=False` paths.