### PR TITLE
docs: align guardrails Speckit with hybrid Bedrock pool model

### DIFF
--- a/specs/001-project-guardrails-config/checklists/requirements.md
+++ b/specs/001-project-guardrails-config/checklists/requirements.md
@@ -30,3 +30,4 @@
 - 2026-07-20: Confirmation moved to frontend-only (FDD modal); backend persists unblock immediately — no `confirm_disable` / `409`.
 - 2026-07-06 clarify (naming): *topic* → **guardrail category**; *topic_states* → **category_states**; backend i18n out of scope (T002 dropped).
 - 2026-07-16: Runtime redesigned — `ApplyGuardrail` in Nexus preprocess (INPUT only), one Bedrock guardrail per project, omit unblocked categories on sync, blocking message Option A (Nexus message, ignore Bedrock canned text). Replaced payload/`categories` map for Models + Lambda path.
+- 2026-07-22: **Superseded 1:1 Guardrail/project** → hybrid **pool** by blocked-category combination (lazy CreateGuardrail, shared across projects, message Option A, no language in pool key). Prompt soft layer + OUTPUT deferred. IAM/quota via Cloud; no console pre-create.

--- a/specs/001-project-guardrails-config/data-model.md
+++ b/specs/001-project-guardrails-config/data-model.md
@@ -11,7 +11,7 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 | slug | string | Stable key, e.g. `politics`, `physical_health` |
 | name | string | English label in settings (Bedrock/docs; **not** returned by API) |
 | description | string | English scope in settings (Bedrock/docs; **not** returned by API) |
-| bedrock_definition | string | Denied topic definition for Bedrock sync (may equal description) |
+| bedrock_definition | string | Denied topic definition for Bedrock create (may equal description) |
 | bedrock_examples | string[] | Optional sample phrases for Bedrock (max 5) |
 
 **Initial slugs (11)**: `politics`, `physical_health`, `sexual_content`, `bias`, `hate`, `religion`, `suicide`, `self_harm`, `beliefs`, `gender_identity`, `sexual_relations`
@@ -20,17 +20,39 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 
 ---
 
-### ProjectGuardrailsConfig (new model in `nexus/projects/models.py`)
+### BedrockGuardrailPool (new model — registry)
+
+One row per unique combination of blocked catalog slugs.
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| combination_key | CharField / TextField | unique | Deterministic key from sorted blocked slugs (e.g. bitmask or canonical join) |
+| category_slugs | JSONField | list[str] | Slugs with `blocked=true` represented by this pool |
+| bedrock_guardrail_identifier | CharField | required after create | AWS Guardrail id |
+| bedrock_guardrail_version | CharField | required after create | AWS version string |
+| created_on / modified_on | DateTime | auto | |
+
+**Rules**
+
+- Key **excludes** project language and blocking message.
+- Lazy create: first project that needs a missing combination calls `CreateGuardrail`.
+- Reuse: subsequent projects with the same key only point at this row.
+
+---
+
+### ProjectGuardrailsConfig (model in `nexus/projects/models.py`)
 
 | Field | Type | Constraints | Notes |
 |-------|------|-------------|-------|
 | project | OneToOne → Project | CASCADE | |
 | category_states | JSONField | `{slug: bool}` | `true` = blocked |
 | blocking_message | TextField | null, max 240 | null = use `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE` |
-| bedrock_guardrail_identifier | CharField | null/blank until first sync | Bedrock Guardrail id |
-| bedrock_guardrail_version | CharField | null/blank until first sync | Bedrock version string |
+| bedrock_guardrail_identifier | CharField | null/blank until assigned | Copy/pointer of assigned pool id |
+| bedrock_guardrail_version | CharField | null/blank until assigned | Copy/pointer of assigned pool version |
 | created_on / modified_on | DateTime | auto | |
 | initialized_as_new_project | Boolean | default False | Audit for lazy init |
+
+Optional FK to `BedrockGuardrailPool` may be used instead of (or in addition to) denormalized id/version — implementation MUST keep a single source of truth for ApplyGuardrail.
 
 **Validation**
 
@@ -38,26 +60,30 @@ Fixed catalog in `settings.GUARDRAIL_CATEGORY_CATALOG` — defined directly in c
 - Missing slugs filled on read with project-type default.
 - If any category blocked, effective message must be non-empty (custom or settings default).
 
-**Bedrock sync rules**
+**Pool resolve rules**
 
-- Category PATCH → upsert Denied Topics for slugs where `blocked=true` only; persist new identifier/version.
-- Message-only PATCH → local field only; **no** Bedrock update.
-- Existing `Guardrail` model (identifier/version, global/current_version) may be reused or superseded by these fields — implementation MUST keep a single source of truth per project.
+- Category PATCH → compute combination key from `blocked=true` → get_or_create pool (lazy Bedrock create) → persist id/version on project.
+- Message-only PATCH → local field only; **no** Bedrock create/update; pool assignment unchanged.
+- All unblocked → skip ApplyGuardrail; clear or ignore pool pointer as implemented.
 
 ---
 
 ## State Transitions
 
 ```
-blocked --PATCH--> unblocked --> Bedrock sync (omit category)
-unblocked --PATCH--> blocked --> Bedrock sync (include category)
+blocked --PATCH--> unblocked --> resolve pool for new combination (reuse or lazy create)
+unblocked --PATCH--> blocked --> resolve pool for new combination (reuse or lazy create)
 
-(no row) --first GET--> lazy init --> row [--> create/sync Bedrock when any blocked]
+(no pool row) --first need--> CreateGuardrail --> registry row
+(project A, project B, same subset) --> same pool identifier/version
+
+(no ProjectGuardrailsConfig row) --first GET--> lazy init --> row
 
 ApplyGuardrail INTERVENED --> return project effective message (ignore Bedrock canned text)
 ```
 
 ## Migration notes
 
-- Single migration; no backfill of historical conversations; new catalog slugs merged at read time.
-- Bedrock resources created lazily on first sync need (lazy init and/or first category PATCH).
+- Migrations for `ProjectGuardrailsConfig` fields and `BedrockGuardrailPool` (or equivalent).
+- No backfill of historical conversations; new catalog slugs merged at read time.
+- Bedrock resources created lazily on first resolve need — not pre-created by Cloud/console.

--- a/specs/001-project-guardrails-config/plan.md
+++ b/specs/001-project-guardrails-config/plan.md
@@ -1,12 +1,12 @@
 # Implementation Plan: Project Guardrails Category Configuration
 
-**Branch**: `001-project-guardrails-config` | **Date**: 2026-07-16 | **Spec**: [spec.md](./spec.md)
+**Branch**: `001-project-guardrails-config` / `feat/guardrails-bedrock-pool-registry` | **Date**: 2026-07-22 | **Spec**: [spec.md](./spec.md)
 
-**Scope**: Nexus backend only — models, API, use cases, Bedrock Guardrail sync, `ApplyGuardrail` preprocess gate, cache invalidation, tests.
+**Scope**: Nexus backend only — models, API, use cases, Bedrock Guardrail **pool registry** (lazy create), `ApplyGuardrail` preprocess gate, cache invalidation, tests.
 
 ## Summary
 
-Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, immediate unblock (confirmation UX is frontend-only), **one Bedrock Guardrail per project** synced with only blocked categories, **`ApplyGuardrail` on INPUT** in existing preprocess (Option A message resolution), cache invalidation. No backend i18n. No Lambda for this flow.
+Add project-level guardrails configuration to Nexus: fixed 11-**category** catalog (`GUARDRAIL_CATEGORY_CATALOG`), per-category `blocked` boolean in `category_states`, single blocking message (≤240 chars), admin-only PATCH, lazy defaults, immediate unblock (confirmation UX is frontend-only), **hybrid Bedrock Guardrail pools** keyed by blocked-category combination (lazy `CreateGuardrail`, shared across projects), **`ApplyGuardrail` on INPUT** in existing preprocess (Option A message resolution), cache invalidation. No backend i18n. No Lambda for this flow. No system-prompt soft layer / OUTPUT in this release.
 
 ## Technical Context
 
@@ -14,19 +14,19 @@ Add project-level guardrails configuration to Nexus: fixed 11-**category** catal
 
 **Primary Dependencies**: DRF, drf-spectacular, boto3 (`bedrock` + `bedrock-runtime`), `GuardrailsUsecase`, `CacheService`, `router/tasks/invoke.py` preprocess
 
-**Storage**: PostgreSQL — `ProjectGuardrailsConfig` (JSONField + TextField + Bedrock id/version)
+**Storage**: PostgreSQL — `ProjectGuardrailsConfig` + `BedrockGuardrailPool` (or equivalent registry)
 
-**Testing**: pytest / Django TestCase / APIClient in `nexus/` and `router/`; Bedrock clients mocked
+**Testing**: pytest / Django TestCase / APIClient in `nexus/` and `router/`; Bedrock clients mocked (E2E against real AWS waits on Cloud IAM)
 
 **Target Platform**: Linux (Nexus API + Router workers)
 
 **Project Type**: Backend web service (REST API + pre-input Bedrock gate)
 
-**Performance Goals**: GET/PATCH p95 < 200ms (excluding Bedrock sync); `ApplyGuardrail` on critical path — measure and budget; reuse `GUARDRAILS_TTL` cache for id/version + effective message
+**Performance Goals**: GET/PATCH p95 < 200ms (excluding first-time pool create); `ApplyGuardrail` on critical path — measure and budget; reuse `GUARDRAILS_TTL` cache for id/version + effective message
 
-**Constraints**: 240-char message; admin-only writes; last-write-wins; no retroactive rewrite; INPUT-only; message-only PATCH skips Bedrock update
+**Constraints**: 240-char message; admin-only writes; last-write-wins; no retroactive rewrite; INPUT-only; message-only PATCH skips Bedrock; pool key has no language
 
-**Scale/Scope**: All projects; 11 categories v1; uniform per project
+**Scale/Scope**: All projects; 11 categories v1; ≤ 2^11 pool combinations in theory (lazy; far fewer in practice)
 
 ## Constitution Check
 
@@ -36,7 +36,7 @@ Add project-level guardrails configuration to Nexus: fixed 11-**category** catal
 | Tests for new API + use case + ApplyGuardrail path | PASS |
 | Cache invalidation on mutation | PASS |
 | 240-char validation | PASS |
-| Scope: no per-agent / custom categories / Lambda | PASS |
+| Scope: no per-agent / custom categories / Lambda / prompt soft layer | PASS |
 
 ## Project Structure
 
@@ -55,7 +55,7 @@ specs/001-project-guardrails-config/
 ```text
 nexus/
 ├── projects/
-│   ├── models.py                    # ProjectGuardrailsConfig (OneToOne Project)
+│   ├── models.py                    # ProjectGuardrailsConfig + BedrockGuardrailPool
 │   ├── migrations/
 │   └── api/
 │       ├── routers.py
@@ -65,8 +65,8 @@ nexus/
 ├── usecases/guardrails/
 │   ├── guardrails_usecase.py        # resolve config + ApplyGuardrail gate helpers
 │   ├── project_guardrails_config.py # get/merge/init/update
-│   └── bedrock_guardrail_sync.py    # create/update/version Denied Topics subset
-└── settings.py                      # GUARDRAIL_CATEGORY_CATALOG + default message
+│   └── bedrock_guardrail_pool.py    # combination key, get_or_create pool, CreateGuardrail
+└── settings.py                      # GUARDRAIL_CATEGORY_CATALOG + default message + baseline
 
 router/
 ├── services/cache_service.py

--- a/specs/001-project-guardrails-config/quickstart.md
+++ b/specs/001-project-guardrails-config/quickstart.md
@@ -5,30 +5,34 @@
 curl -s -H "Authorization: Bearer $TOKEN" \
   "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 2. Block a category
+# 2. Block a category (resolves/assigns Bedrock pool for the combination)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"category_states": {"politics": true}}' \
   "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 3. Unblock a category (persists immediately; FE may show a modal before this call)
+# 3. Unblock a category (persists immediately; reassigns pool; FE may show a modal before this call)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"category_states": {"politics": false}}' \
   "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 4. Message-only PATCH
+# 4. Message-only PATCH (no Bedrock Create/Update; pool unchanged)
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"blocking_message": "I cannot help with that request."}' \
   "http://localhost:8000/api/$PROJECT_UUID/guardrails-config/" | jq
 
-# 5. Inspect persisted config
+# 5. Inspect persisted config + assigned pool id/version
 python manage.py shell -c "
 from nexus.projects.models import ProjectGuardrailsConfig
 c = ProjectGuardrailsConfig.objects.get(project__uuid='$PROJECT_UUID')
 print(c.category_states, c.blocking_message)
+print(c.bedrock_guardrail_identifier, c.bedrock_guardrail_version)
 "
+
+# Real CreateGuardrail / ApplyGuardrail in staging requires Cloud IAM.
+# Local/CI: mock boto3. E2E against AWS after IAM + quota are ready.
 
 pytest nexus/projects/api/tests/test_guardrails_config.py nexus/usecases/guardrails/tests/ -q -k guardrail
 ```

--- a/specs/001-project-guardrails-config/research.md
+++ b/specs/001-project-guardrails-config/research.md
@@ -47,26 +47,30 @@ Unchanged from 2026-07-06 product/API clarifications.
 
 ---
 
-## R5 — One Bedrock Guardrail per project; omit unblocked categories
+## R5 — Hybrid Bedrock Guardrail pool (supersedes 1:1 per project)
 
-**Decision**: Each project owns one Bedrock Guardrail (`identifier` + `version` persisted). On category PATCH, sync Denied Topics to include **only** `blocked=true` catalog entries. Unblocked categories are omitted from the policy.
+**Decision (2026-07-22)**: Maintain a **pool registry** keyed by the combination of `blocked=true` catalog slugs (no language). On category PATCH, resolve the pool: **reuse** if the combination exists; otherwise **lazy `CreateGuardrail`** with Denied Topics for that subset (+ platform baseline content filters/PII when Models defines them). Persist assigned `identifier`/`version` on the project. Projects with the same subset share one AWS Guardrail.
 
-**Rationale**: Bedrock evaluates configured denied topics as a set; toggles are expressed by presence/absence in the guardrail definition, not by a separate runtime map.
+**Rationale**: Operators cannot create custom topics (FDD) — combination space is finite. Models guidance: 1:1 per project does not scale operationally; temporary per-request Guardrails are impossible; custom messaging must stay outside Bedrock so pools can be shared (Option A).
 
 **When all unblocked**: skip `ApplyGuardrail` at preprocess (no-op).
+
+**Rejected**: One Bedrock Guardrail resource owned exclusively per project with UpdateGuardrail on every toggle (previous R5, 2026-07-16).
+
+**Deferred**: Soft layer — inject denied topics into manager system prompt; OUTPUT `ApplyGuardrail`.
 
 ---
 
 ## R6 — Blocking message Option A
 
-**Decision**: On `GUARDRAIL_INTERVENED`, Nexus ignores Bedrock canned output and returns the project effective message (custom or `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`). Message-only PATCH does not UpdateGuardrail / bump version.
+**Decision**: On `GUARDRAIL_INTERVENED`, Nexus ignores Bedrock canned output and returns the project effective message (custom or `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`). Message-only PATCH does not Create/Update Guardrail or change pool assignment.
 
-**Rationale**: Message changes are more frequent than topic toggles; avoids unnecessary Bedrock version churn. Customer-facing copy stays owned by Nexus/project config.
+**Rationale**: Message changes are more frequent than topic toggles; pooling requires message outside the shared Guardrail. Customer-facing copy stays owned by Nexus/project config.
 
-**Rejected**: Option B — store project message in `blockedInputMessaging` and return Bedrock text as-is.
+**Rejected**: Option B — store project message in `blockedInputMessaging` and return Bedrock text as-is (blocks pool sharing).
 
 ---
 
 ## R7 — Fail behavior on Bedrock errors (open)
 
-**Decision pending implementation**: Document and test whether preprocess **fail-open** (allow message) or **fail-closed** (block/safe reply) when `ApplyGuardrail` or sync APIs error. Prefer explicit choice in plan/tasks before release.
+**Decision pending implementation**: Document and test whether preprocess **fail-open** (allow message) or **fail-closed** (block/safe reply) when `ApplyGuardrail` or pool create/resolve APIs error. Prefer explicit choice in plan/tasks before release.

--- a/specs/001-project-guardrails-config/spec.md
+++ b/specs/001-project-guardrails-config/spec.md
@@ -8,7 +8,7 @@
 
 **Input**: FDD V2 — Configuração de tópicos de guardrails por projeto (Jade Castro, 2026-06-23)
 
-**Scope**: Nexus backend only — persistence, API, validation, Bedrock Guardrail sync (one per project), `ApplyGuardrail` on user input preprocess, cache. No frontend or UI work in this feature.
+**Scope**: Nexus backend only — persistence, API, validation, Bedrock Guardrail **pool** (lazy create by category combination), `ApplyGuardrail` on user input preprocess, cache. No frontend or UI work in this feature.
 
 **Terminology**: Use **guardrail category** (not *topic*) to avoid collision with conversation `Topics` (`nexus.intelligences.models.Topics`, lambda classifier). Use **category** (not *instruction*) to avoid collision with agent/content-base instructions.
 
@@ -30,10 +30,16 @@
 ### Session 2026-07-16
 
 - Q: Where does the refusal check run? → A: **`ApplyGuardrail` in Nexus preprocess**, before each user input. Not via conversation/guardrails Lambda.
-- Q: One Bedrock guardrail per project? → A: **Yes.** Categories with `blocked=false` are **omitted** from the Bedrock Denied Topics policy (not passed as inactive entries).
-- Q: Blocking message source? → A: **Option A** — on `GUARDRAIL_INTERVENED`, Nexus **ignores** Bedrock canned text and returns the project custom message or `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`. Message-only PATCH does **not** require Bedrock UpdateGuardrail.
+- Q: Blocking message source? → A: **Option A** — on `GUARDRAIL_INTERVENED`, Nexus **ignores** Bedrock canned text and returns the project custom message or `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`. Message-only PATCH does **not** require Bedrock Create/Update.
 - Q: INPUT and/or OUTPUT? → A: **INPUT only** (`source=INPUT`).
 - Q: OpenAI vs Bedrock backends? → A: Reuse the existing preprocess/`invoke` path for both; do not invent a parallel pipeline.
+
+### Session 2026-07-22
+
+- Q: One Bedrock Guardrail per project? → A: **Superseded.** Use **hybrid pool** (Models guidance): one Bedrock Guardrail per **combination** of `blocked=true` catalog categories; projects with the same subset **share** that Guardrail. Nexus creates pools **lazily** via API (not pre-created in AWS console).
+- Q: Pool key includes project language? → A: **No.** Key = subset of blocked category slugs only. Custom message is always applied outside Bedrock (Option A).
+- Q: Can operators create new Guardrails/topics? → A: **No** (FDD). Operators only toggle the fixed catalog + blocking message.
+- Q: System prompt injection of denied topics / OUTPUT ApplyGuardrail? → A: **Out of scope** for this release (phase 2 if needed after hard path is stable).
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -41,15 +47,16 @@
 
 As an authenticated admin API consumer, I need to read and update per-category blocked states for a project so guardrail behavior can be controlled without engineering intervention.
 
-**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked, verify Bedrock sync omits the unblocked category and the next input no longer blocks that category.
+**Independent Test**: `GET` config, `PATCH` one category from blocked to unblocked, verify the project is reassigned to the pool for the new combination and the next input no longer blocks that category.
 
 **Acceptance Scenarios**:
 
 1. **Given** valid project UUID and auth, **When** `GET /guardrails-config/`, **Then** response lists all fixed catalog categories with `slug` and `blocked` (no `name`/`description`).
-2. **Given** category blocked, **When** PATCH unblocks it, **Then** persists immediately, syncs Bedrock guardrail without that category, and runtime no longer blocks it.
-3. **Given** category unblocked, **When** PATCH blocks it, **Then** persists immediately and syncs Bedrock including that category.
-4. **Given** PATCH unblocks all categories, **Then** all categories unblocked and Bedrock sync reflects no denied categories (runtime skips `ApplyGuardrail` or never intervenes).
+2. **Given** category blocked, **When** PATCH unblocks it, **Then** persists immediately, resolves/assigns the Bedrock pool for the new combination (lazy create if missing), and runtime no longer blocks that category.
+3. **Given** category unblocked, **When** PATCH blocks it, **Then** persists immediately and assigns the pool that includes that category.
+4. **Given** PATCH unblocks all categories, **Then** all categories unblocked and runtime skips `ApplyGuardrail` (or never intervenes).
 5. **Given** operator wants UX confirmation before unblocking, **When** Agent Builder shows a modal, **Then** FE calls PATCH once after confirm (backend does not enforce a two-step handshake).
+6. **Given** two projects with the same `blocked=true` subset, **Then** both persist the same Bedrock `identifier`/`version` (shared pool).
 
 ---
 
@@ -63,7 +70,7 @@ As an authenticated admin API consumer, I need to persist a project blocking mes
 
 1. **Given** no custom message, **When** GET, **Then** `blocking_message` is platform default from settings and `blocking_message_is_custom: false`.
 2. **Given** category blocked, **When** customer message triggers `ApplyGuardrail` at preprocess, **Then** Nexus returns project blocking message (Option A).
-3. **Given** PATCH message ≤240 chars, **When** saved, **Then** GET reflects custom message; next intervene uses it **without** Bedrock guardrail version bump for message-only change.
+3. **Given** PATCH message ≤240 chars, **When** saved, **Then** GET reflects custom message; next intervene uses it **without** Bedrock Create/Update (shared pool unchanged).
 4. **Given** PATCH message >240 chars, **When** validated, **Then** `400`.
 
 ---
@@ -72,13 +79,13 @@ As an authenticated admin API consumer, I need to persist a project blocking mes
 
 As the platform, guardrails config MUST apply uniformly to all agents in the project via a single pre-input check.
 
-**Independent Test**: Same project Bedrock guardrail + project message used in preprocess for every agent/backend path that shares `invoke` preprocess; updates after category PATCH + Bedrock sync + cache invalidation.
+**Independent Test**: Project’s assigned pool id/version + project message used in preprocess for every agent/backend path that shares `invoke` preprocess; updates after category PATCH + pool resolve + cache invalidation.
 
 **Acceptance Scenarios**:
 
-1. **Given** new project, **When** first GET lazy init, **Then** all categories blocked + platform default message + Bedrock guardrail created/synced with all catalog denied topics.
-2. **Given** existing project, **When** first GET lazy init, **Then** all categories unblocked + platform default message (no denied topics on Bedrock / skip apply as defined).
-3. **Given** category PATCH applied and synced, **When** next user input is processed, **Then** `ApplyGuardrail` uses the new guardrail version; prior responses unchanged.
+1. **Given** new project, **When** first GET lazy init, **Then** all categories blocked + platform default message; Bedrock pool for the full blocked set is created/assigned on first category sync need (lazy).
+2. **Given** existing project, **When** first GET lazy init, **Then** all categories unblocked + platform default message (no ApplyGuardrail until something is blocked).
+3. **Given** category PATCH applied and pool resolved, **When** next user input is processed, **Then** `ApplyGuardrail` uses the assigned pool identifier/version; prior responses unchanged.
 
 ---
 
@@ -86,12 +93,13 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 
 - Multiple blocked categories match one message → single project blocking message (not per-category).
 - Empty/whitespace `blocking_message` while any category blocked → `400`.
-- Config changed mid-conversation → applies after successful PATCH (+ Bedrock sync when categories change) only.
-- New catalog slug in deploy → merged on GET with project-type default; next category sync includes it when blocked.
+- Config changed mid-conversation → applies after successful PATCH (+ pool resolve when categories change) only.
+- New catalog slug in deploy → merged on GET with project-type default; pool keys that include the new slug are new combinations (lazy create when first needed).
 - Non-admin PATCH → `403`; GET returns `writable: false`.
 - Concurrent PATCH → last write wins.
-- Bedrock sync failure on category PATCH → PATCH MUST NOT leave local config and Bedrock permanently inconsistent without a defined error path (fail the request or report sync error; do not silently succeed).
-- All categories unblocked → do not call `ApplyGuardrail` (or equivalent no-op with empty denied topics).
+- Bedrock pool create/resolve failure on category PATCH → PATCH MUST NOT leave local config and Bedrock assignment permanently inconsistent without a defined error path (fail the request; do not silently succeed).
+- All categories unblocked → do not call `ApplyGuardrail` (clear or ignore pool pointer as implemented).
+- Same category subset across projects → **must** reuse one Bedrock Guardrail pool (no 1:1 create).
 
 ## Requirements *(mandatory)*
 
@@ -108,42 +116,45 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 - **FR-009**: PATCH unblocking categories persists immediately (confirmation UX is frontend-only).
 - **FR-010**: PATCH may unblock all categories in one request.
 - **FR-011**: PATCH blocking and unblocking categories use the same request shape (`category_states`).
-- **FR-012**: Runtime MUST evaluate each user input with Bedrock `ApplyGuardrail` (`source=INPUT`) using the project's guardrail identifier/version **before** agent processing, reusing the existing preprocess/`invoke` path (no dedicated OpenAI-only pipeline; no `GUARDRAILS_LAYER_LAMBDA` for this flow).
-- **FR-013**: Changes apply only to messages after successful PATCH (and successful Bedrock sync when categories change).
+- **FR-012**: Runtime MUST evaluate each user input with Bedrock `ApplyGuardrail` (`source=INPUT`) using the project's assigned pool identifier/version **before** agent processing, reusing the existing preprocess/`invoke` path (no dedicated OpenAI-only pipeline; no `GUARDRAILS_LAYER_LAMBDA` for this flow).
+- **FR-013**: Changes apply only to messages after successful PATCH (and successful pool resolve when categories change).
 - **FR-014**: GET merges new catalog slugs with project-type defaults.
 - **FR-015**: GET returns platform default blocking message from settings when no custom message stored.
 - **FR-016**: Custom blocking messages stored without auto-translation.
 - **FR-017**: No operator CRUD on catalog category definitions.
 - **FR-018**: No per-agent guardrails config in this release.
 - **FR-019**: No per-category blocking messages in this release.
-- **FR-020**: Each project MUST have at most one Bedrock Guardrail resource; identifier and version MUST be persisted with the project config.
-- **FR-021**: On category-state PATCH, Nexus MUST sync Bedrock Denied Topics to include **only** categories with `blocked=true` (omit unblocked categories).
+- **FR-020**: Nexus MUST maintain a **registry of Bedrock Guardrail pools** keyed by the combination of `blocked=true` catalog slugs (no language in the key). Each project MUST persist the assigned pool `identifier`/`version`. Projects with the same combination MUST share the same pool.
+- **FR-021**: On category-state PATCH, Nexus MUST resolve the pool for the new combination: reuse registry entry if present; otherwise **lazy** `CreateGuardrail` with Denied Topics = only `blocked=true` categories (plus platform baseline filters/PII when defined), then persist id/version on the project.
 - **FR-022**: On `GUARDRAIL_INTERVENED`, Nexus MUST return the project effective blocking message and MUST NOT use Bedrock canned output text as the customer-facing reply (Option A).
-- **FR-023**: Message-only PATCH MUST persist locally and MUST NOT require Bedrock UpdateGuardrail / version bump.
+- **FR-023**: Message-only PATCH MUST persist locally and MUST NOT Create/Update Bedrock Guardrail or change the project's pool assignment.
 - **FR-024**: Guardrail evaluation is INPUT-only; OUTPUT evaluation is out of scope.
 - **FR-025**: When no categories are blocked, runtime MUST skip `ApplyGuardrail` (or equivalent no intervention).
 
 ### Key Entities
 
 - **Guardrail category (catalog entry)**: Platform slug (+ Bedrock denied-topic definition/examples as needed); display name/description are frontend i18n; not mutable via API.
-- **Project guardrails configuration**: One-to-one with project; `category_states` + optional custom blocking message + Bedrock guardrail identifier/version.
+- **Bedrock Guardrail pool**: One AWS Guardrail resource per unique blocked-category combination; owned by Nexus registry; created lazily.
+- **Project guardrails configuration**: One-to-one with project; `category_states` + optional custom blocking message + assigned pool identifier/version.
 
 ## Success Criteria *(mandatory)*
 
 - **SC-001**: Admin can GET/PATCH all 11 categories + message in one API session.
 - **SC-002**: 100% of over-limit message PATCH attempts return `400`.
-- **SC-003**: After category PATCH + Bedrock sync, the next user input is evaluated with the updated denied-topic set; on intervene, customer receives the project effective message (Option A).
+- **SC-003**: After category PATCH + pool resolve, the next user input is evaluated with the assigned pool; on intervene, customer receives the project effective message (Option A).
 - **SC-004**: 100% of non-admin PATCH return `403`.
 - **SC-005**: First GET: new projects all blocked; existing all unblocked.
 - **SC-006**: Unblock PATCH persists immediately without a backend confirmation handshake.
 - **SC-007**: Preprocess guardrail path does not invoke `GUARDRAILS_LAYER_LAMBDA` for this feature.
+- **SC-008**: Two projects with identical blocked subsets share one Bedrock Guardrail identifier.
 
 ## Assumptions
 
 - Conversation **Topics** (`Topics` model, lambda classifier) are a separate domain — no shared tables or APIs.
 - Catalog display labels are frontend-owned (i18n by `slug`); API returns only `slug` + `blocked`.
-- Bedrock Denied Topics are the enforcement mechanism; Nexus owns sync + `ApplyGuardrail` + customer-facing message resolution.
+- Bedrock Denied Topics (+ optional baseline content filters/PII) are the hard enforcement mechanism; Nexus owns pool registry, lazy create, `ApplyGuardrail`, and customer-facing message resolution.
 - Fail-open vs fail-closed on Bedrock API errors during preprocess is an implementation decision to document in research/plan and cover with tests.
+- IAM/quota for Bedrock Guardrails is provided by Platform/Cloud; pools are **not** pre-created in the AWS console.
 
 ## Out of Scope
 
@@ -151,7 +162,9 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 - Per-agent guardrails, custom categories, per-category messages, auto-translation
 - Frontend/UI, API `Accept-Language`, backend locale modules
 - OUTPUT guardrail evaluation
+- Injecting project denied topics into the manager system prompt (soft layer)
 - Reintroducing Lambda-based guardrails complexity layer for this flow
+- Pre-provisioning all pool combinations in AWS by hand
 
 ## API References
 
@@ -164,6 +177,7 @@ As the platform, guardrails config MUST apply uniformly to all agents in the pro
 
 | Dependency | Owner |
 |------------|-------|
-| Bedrock Guardrails create/update/version + `ApplyGuardrail` | Nexus backend |
-| Persistence, admin API, preprocess gate, cache | Nexus backend |
-| IAM / AWS account access for Bedrock Guardrails | Platform / DevOps |
+| Bedrock Guardrails lazy create + `ApplyGuardrail` | Nexus backend |
+| Persistence, admin API, preprocess gate, cache, pool registry | Nexus backend |
+| IAM / AWS account access + quota for Bedrock Guardrails | Platform / DevOps (Cloud) |
+| Denied topic definition/examples + baseline filter policy content | AI Models (as needed) |

--- a/specs/001-project-guardrails-config/tasks.md
+++ b/specs/001-project-guardrails-config/tasks.md
@@ -4,42 +4,47 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Add `GUARDRAIL_CATEGORY_CATALOG` (incl. Bedrock definition/examples), `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`, and `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` to `nexus/settings.py`
+- [x] T001 Add `GUARDRAIL_CATEGORY_CATALOG` (incl. Bedrock definition/examples), `GUARDRAILS_DEFAULT_BLOCKING_MESSAGE`, and `GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT` to `nexus/settings.py`
 
 ## Phase 2: Foundational
 
-- [ ] T002 Create `ProjectGuardrailsConfig` model in `nexus/projects/models.py` with `category_states`, `blocking_message`, `bedrock_guardrail_identifier`, `bedrock_guardrail_version`, and `clean()`
-- [ ] T003 Add migration in `nexus/projects/migrations/`
-- [ ] T004 [P] Implement `ProjectGuardrailsConfigUseCase` in `nexus/usecases/guardrails/project_guardrails_config.py`
-- [ ] T005 [P] Add `GuardrailsConfigAdminPermission` in `nexus/projects/api/permissions.py`
+- [x] T002 Create `ProjectGuardrailsConfig` model in `nexus/projects/models.py` with `category_states`, `blocking_message`, `bedrock_guardrail_identifier`, `bedrock_guardrail_version`, and `clean()`
+- [x] T003 Add migration in `nexus/projects/migrations/`
+- [x] T004 [P] Implement `ProjectGuardrailsConfigUseCase` in `nexus/usecases/guardrails/project_guardrails_config.py`
+- [x] T005 [P] Add `GuardrailsConfigAdminPermission` in `nexus/projects/api/permissions.py`
 
 ## Phase 3: User Story 1 — Category blocked states (P1)
 
-- [ ] T006 [US1] Serializers in `nexus/projects/api/serializers.py` (`categories` in response, `category_states` in PATCH)
-- [ ] T007 [US1] `ProjectGuardrailsConfigView` GET/PATCH in `nexus/projects/api/views.py`
-- [ ] T008 [US1] Route in `nexus/projects/api/routers.py`
+- [x] T006 [US1] Serializers in `nexus/projects/api/serializers.py` (`categories` in response, `category_states` in PATCH)
+- [x] T007 [US1] `ProjectGuardrailsConfigView` GET/PATCH in `nexus/projects/api/views.py`
+- [x] T008 [US1] Route in `nexus/projects/api/routers.py`
 - [x] T009 [US1] Unblock persists immediately (no backend confirmation handshake)
-- [ ] T010 [P] [US1] Tests in `nexus/projects/api/tests/test_guardrails_config.py`
+- [x] T010 [P] [US1] Tests in `nexus/projects/api/tests/test_guardrails_config.py`
 
 ## Phase 4: User Story 2 — Blocking message (P2)
 
-- [ ] T011 [US2] Message validation (240 chars, non-empty when blocked) in serializers
-- [ ] T012 [P] [US2] Message validation tests (message-only PATCH does not call Bedrock update)
+- [x] T011 [US2] Message validation (240 chars, non-empty when blocked) in serializers
+- [x] T012 [P] [US2] Message validation tests (message-only PATCH does not call Bedrock update)
 
-## Phase 5: Bedrock sync (P1)
+## Phase 5: Bedrock pool registry (P1) — NEXUS-5699
 
-- [ ] T013 [US1/US3] Implement Bedrock sync service (`create`/`update`/`version`) with Denied Topics = only `blocked=true` categories
-- [ ] T014 [US1/US3] Wire category PATCH → sync; persist identifier/version; fail request on sync failure
-- [ ] T015 [P] Sync unit tests (omit unblocked; all-unblocked; mock boto3)
+- [ ] T013 [US1/US3] `BedrockGuardrailPool` model/migration + combination key helper
+- [ ] T014 [US1/US3] Pool service: get_or_create + lazy `CreateGuardrail` (Denied Topics = `blocked=true` only; baseline when available); reuse existing pool
+- [ ] T015 [P] Pool unit tests (create, reuse, all-unblocked / no create; mock boto3)
 
-## Phase 6: User Story 3 — Runtime ApplyGuardrail (P1)
+## Phase 5b: Wire PATCH to pool (P1) — NEXUS-5725
+
+- [ ] T015b [US1] Wire category PATCH → resolve pool → persist id/version on project; fail PATCH on resolve/create failure
+- [ ] T015c [P] API/use case tests: assign, two projects share pool, message-only skips Bedrock, failure path
+
+## Phase 6: User Story 3 — Runtime ApplyGuardrail (P1) — NEXUS-5644
 
 - [ ] T016 [US3] Preprocess gate in `router/tasks/invoke.py`: `ApplyGuardrail` `source=INPUT`; skip when no categories blocked; **no** `GUARDRAILS_LAYER_LAMBDA`
 - [ ] T017 [US3] On `GUARDRAIL_INTERVENED`, return project effective blocking message (Option A); reuse existing early-exit / `UnsafeMessageException` patterns
 - [ ] T018 [US3] Cache id/version + effective message; invalidate on PATCH
 - [ ] T019 [P] [US3] Router/usecase tests: intervene → project message; pass-through; skip when all unblocked; no Lambda invoke
 
-## Phase 7: Polish
+## Phase 7: Polish — NEXUS-5645
 
 - [ ] T020 [P] drf-spectacular annotations on view
 - [ ] T021 Run `quickstart.md` scenarios
@@ -51,4 +56,8 @@
 
 **Removed**: “extend runtime payload with `categories` map for Models” — replaced by ApplyGuardrail + Option A.
 
-**MVP**: Phases 1–3 + Phase 5–6 (API + sync + preprocess gate).
+**Superseded (2026-07-22)**: “one Guardrail per project + UpdateGuardrail on PATCH” → hybrid pool registry + lazy Create + shared assignment.
+
+**Deferred**: system prompt denied-topics injection; OUTPUT ApplyGuardrail.
+
+**MVP**: Phases 1–4 (done) + Phase 5–6 (pool + wire + preprocess gate).


### PR DESCRIPTION
## Summary
- Updates Speckit (`001-project-guardrails-config`) from 1 Guardrail/project to hybrid **pool** by blocked-category combination (lazy CreateGuardrail, shared across projects).
- Keeps Option A messaging, INPUT-only ApplyGuardrail; defers prompt soft layer / OUTPUT.
- Aligns with NEXUS-5699 / Models guidance.

## Test plan
- [ ] Review `spec.md` FR-020/021 and session 2026-07-22
- [ ] Review `research.md` R5, `data-model.md` BedrockGuardrailPool
- [ ] Confirm HTTP contract unchanged (API shape)


Made with [Cursor](https://cursor.com)