### PR TITLE
feat: assign Bedrock guardrail pool to config on category state update with 502 on failure

### DIFF
--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -7,32 +7,13 @@ from django.utils import timezone as django_timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from nexus.projects.models import BedrockGuardrailPool, Project, ProjectAuthorizationRole, ProjectGuardrailsConfig
+from nexus.projects.models import Project, ProjectAuthorizationRole, ProjectGuardrailsConfig
 from nexus.projects.permissions import has_project_permission
-from nexus.usecases.guardrails.bedrock_guardrail_pool import (
-    BedrockGuardrailPoolError,
-    BedrockGuardrailPoolService,
-    ResolvedGuardrailPool,
-)
+from nexus.usecases.guardrails.bedrock_guardrail_pool import BedrockGuardrailPoolError
 from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
+from nexus.usecases.guardrails.tests.guardrail_test_helpers import fake_pool_resolve as _fake_pool_resolve
 from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
-
-
-def _fake_pool_resolve(category_states, client=None):
-    blocked = BedrockGuardrailPoolService.blocked_slugs_from_states(category_states)
-    if not blocked:
-        return None
-    key = BedrockGuardrailPoolService.combination_key(blocked)
-    pool, created = BedrockGuardrailPool.objects.get_or_create(
-        combination_key=key,
-        defaults={
-            "category_slugs": blocked,
-            "bedrock_guardrail_identifier": f"gr-{key[:40]}",
-            "bedrock_guardrail_version": "1",
-        },
-    )
-    return ResolvedGuardrailPool(pool=pool, created=created)
 
 
 @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))

--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -7,11 +7,32 @@ from django.utils import timezone as django_timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from nexus.projects.models import Project, ProjectAuthorizationRole, ProjectGuardrailsConfig
+from nexus.projects.models import BedrockGuardrailPool, Project, ProjectAuthorizationRole, ProjectGuardrailsConfig
 from nexus.projects.permissions import has_project_permission
+from nexus.usecases.guardrails.bedrock_guardrail_pool import (
+    BedrockGuardrailPoolError,
+    BedrockGuardrailPoolService,
+    ResolvedGuardrailPool,
+)
 from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
 from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
+
+
+def _fake_pool_resolve(category_states, client=None):
+    blocked = BedrockGuardrailPoolService.blocked_slugs_from_states(category_states)
+    if not blocked:
+        return None
+    key = BedrockGuardrailPoolService.combination_key(blocked)
+    pool, created = BedrockGuardrailPool.objects.get_or_create(
+        combination_key=key,
+        defaults={
+            "category_slugs": blocked,
+            "bedrock_guardrail_identifier": f"gr-{key[:40]}",
+            "bedrock_guardrail_version": "1",
+        },
+    )
+    return ResolvedGuardrailPool(pool=pool, created=created)
 
 
 @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
@@ -37,7 +58,14 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         self._mock_ext_permission.side_effect = _local_permission
         self.client.force_authenticate(user=self.user)
 
+        self._pool_patcher = mock.patch(
+            "nexus.usecases.guardrails.project_guardrails_config.BedrockGuardrailPoolService.get_or_create_pool",
+            side_effect=_fake_pool_resolve,
+        )
+        self._mock_get_or_create_pool = self._pool_patcher.start()
+
     def tearDown(self):
+        self._pool_patcher.stop()
         self._patcher.stop()
 
     def test_get_lazy_init_new_project_blocks_all(self):
@@ -109,6 +137,7 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
 
     def test_patch_blocking_message_success(self):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+        self._mock_get_or_create_pool.reset_mock()
 
         response = self.client.patch(
             self.url,
@@ -119,6 +148,42 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["blocking_message_is_custom"])
         self.assertEqual(response.data["blocking_message"], "Custom refusal message")
+        self._mock_get_or_create_pool.assert_not_called()
+
+    def test_patch_category_assigns_pool_on_config(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+        ProjectGuardrailsConfig.objects.filter(project=self.project).update(
+            category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+        )
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": {"politics": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        config = ProjectGuardrailsConfig.objects.get(project=self.project)
+        self.assertIsNotNone(config.bedrock_guardrail_pool_id)
+        self.assertTrue(config.bedrock_guardrail_identifier)
+
+    def test_patch_category_bedrock_failure_returns_502_without_saving(self):
+        ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
+        ProjectGuardrailsConfig.objects.filter(project=self.project).update(
+            category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+        )
+        self._mock_get_or_create_pool.side_effect = BedrockGuardrailPoolError("AccessDenied")
+
+        response = self.client.patch(
+            self.url,
+            {"category_states": {"politics": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+        config = ProjectGuardrailsConfig.objects.get(project=self.project)
+        self.assertFalse(config.category_states["politics"])
+        self.assertIsNone(config.bedrock_guardrail_pool_id)
 
     def test_patch_blocking_message_over_limit_returns_400(self):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -21,6 +21,7 @@ from nexus.projects.exceptions import ProjectDoesNotExist
 from nexus.projects.models import Project, ProjectAuth
 from nexus.projects.permissions import get_user_auth, is_admin
 from nexus.projects.services.improvement_support_email import SendResult, send_improvement_support_ticket
+from nexus.usecases.guardrails.bedrock_guardrail_pool import BedrockGuardrailPoolError
 from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
 from nexus.usecases.projects.conversations import ConversationsUsecase
 from nexus.usecases.projects.dto import UpdateProjectDTO
@@ -833,6 +834,11 @@ class ProjectGuardrailsConfigView(APIView):
             config = ProjectGuardrailsConfigUseCase.update_config(project, **update_kwargs)
         except DjangoValidationError as exc:
             return Response(self._format_validation_error(exc), status=status.HTTP_400_BAD_REQUEST)
+        except BedrockGuardrailPoolError as exc:
+            return Response(
+                {"detail": "Could not resolve Bedrock guardrail pool.", "error": str(exc)},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
 
         payload = ProjectGuardrailsConfigUseCase.to_payload(
             config,

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from nexus.projects.models import Project, ProjectGuardrailsConfig
+from nexus.usecases.guardrails.bedrock_guardrail_pool import BedrockGuardrailPoolService
 
 _UNSET = object()
 
@@ -205,11 +206,33 @@ class ProjectGuardrailsConfigUseCase:
         category_states_changed = next_states != config.category_states
         blocking_message_changed = blocking_message is not _UNSET and next_blocking_message != config.blocking_message
 
+        # Message-only PATCH must not resolve/create Bedrock pools (FR-023).
+        pool_to_assign = None
+        pool_identifier = None
+        pool_version = None
+        if category_states_changed:
+            # Resolve before local save so Bedrock failure leaves config unchanged.
+            resolved = BedrockGuardrailPoolService.get_or_create_pool(next_states)
+            if resolved is not None:
+                pool_to_assign = resolved.pool
+                pool_identifier = resolved.pool.bedrock_guardrail_identifier
+                pool_version = resolved.pool.bedrock_guardrail_version
+
         if category_states_changed or blocking_message_changed:
             update_fields = ["modified_on"]
             if category_states_changed:
                 config.category_states = next_states
-                update_fields.append("category_states")
+                config.bedrock_guardrail_pool = pool_to_assign
+                config.bedrock_guardrail_identifier = pool_identifier
+                config.bedrock_guardrail_version = pool_version
+                update_fields.extend(
+                    [
+                        "category_states",
+                        "bedrock_guardrail_pool",
+                        "bedrock_guardrail_identifier",
+                        "bedrock_guardrail_version",
+                    ]
+                )
             if blocking_message_changed:
                 config.blocking_message = next_blocking_message
                 update_fields.append("blocking_message")

--- a/nexus/usecases/guardrails/tests/guardrail_test_helpers.py
+++ b/nexus/usecases/guardrails/tests/guardrail_test_helpers.py
@@ -1,0 +1,22 @@
+from nexus.projects.models import BedrockGuardrailPool
+from nexus.usecases.guardrails.bedrock_guardrail_pool import (
+    BedrockGuardrailPoolService,
+    ResolvedGuardrailPool,
+)
+
+
+def fake_pool_resolve(category_states, client=None):
+    """Mock Bedrock pool resolve that persists a registry row without calling AWS."""
+    blocked = BedrockGuardrailPoolService.blocked_slugs_from_states(category_states)
+    if not blocked:
+        return None
+    key = BedrockGuardrailPoolService.combination_key(blocked)
+    pool, created = BedrockGuardrailPool.objects.get_or_create(
+        combination_key=key,
+        defaults={
+            "category_slugs": blocked,
+            "bedrock_guardrail_identifier": f"gr-{key[:40]}",
+            "bedrock_guardrail_version": "1",
+        },
+    )
+    return ResolvedGuardrailPool(pool=pool, created=created)

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -7,31 +7,12 @@ from django.utils import timezone as django_timezone
 from rest_framework.request import Request
 
 from nexus.projects.api.permissions import GuardrailsConfigAdminPermission
-from nexus.projects.models import BedrockGuardrailPool, ProjectAuthorizationRole, ProjectGuardrailsConfig
-from nexus.usecases.guardrails.bedrock_guardrail_pool import (
-    BedrockGuardrailPoolError,
-    BedrockGuardrailPoolService,
-    ResolvedGuardrailPool,
-)
+from nexus.projects.models import ProjectAuthorizationRole, ProjectGuardrailsConfig
+from nexus.usecases.guardrails.bedrock_guardrail_pool import BedrockGuardrailPoolError
 from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
+from nexus.usecases.guardrails.tests.guardrail_test_helpers import fake_pool_resolve as _fake_pool_resolve
 from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
-
-
-def _fake_pool_resolve(category_states, client=None):
-    blocked = BedrockGuardrailPoolService.blocked_slugs_from_states(category_states)
-    if not blocked:
-        return None
-    key = BedrockGuardrailPoolService.combination_key(blocked)
-    pool, created = BedrockGuardrailPool.objects.get_or_create(
-        combination_key=key,
-        defaults={
-            "category_slugs": blocked,
-            "bedrock_guardrail_identifier": f"gr-{key[:40]}",
-            "bedrock_guardrail_version": "1",
-        },
-    )
-    return ResolvedGuardrailPool(pool=pool, created=created)
 
 
 class ProjectGuardrailsConfigUseCaseTestCase(TestCase):

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -7,15 +7,44 @@ from django.utils import timezone as django_timezone
 from rest_framework.request import Request
 
 from nexus.projects.api.permissions import GuardrailsConfigAdminPermission
-from nexus.projects.models import ProjectAuthorizationRole, ProjectGuardrailsConfig
+from nexus.projects.models import BedrockGuardrailPool, ProjectAuthorizationRole, ProjectGuardrailsConfig
+from nexus.usecases.guardrails.bedrock_guardrail_pool import (
+    BedrockGuardrailPoolError,
+    BedrockGuardrailPoolService,
+    ResolvedGuardrailPool,
+)
 from nexus.usecases.guardrails.project_guardrails_config import ProjectGuardrailsConfigUseCase
 from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, ProjectFactory
 from nexus.usecases.users.tests.user_factory import UserFactory
 
 
+def _fake_pool_resolve(category_states, client=None):
+    blocked = BedrockGuardrailPoolService.blocked_slugs_from_states(category_states)
+    if not blocked:
+        return None
+    key = BedrockGuardrailPoolService.combination_key(blocked)
+    pool, created = BedrockGuardrailPool.objects.get_or_create(
+        combination_key=key,
+        defaults={
+            "category_slugs": blocked,
+            "bedrock_guardrail_identifier": f"gr-{key[:40]}",
+            "bedrock_guardrail_version": "1",
+        },
+    )
+    return ResolvedGuardrailPool(pool=pool, created=created)
+
+
 class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
     def setUp(self) -> None:
         self.use_case = ProjectGuardrailsConfigUseCase()
+        self._pool_patcher = patch(
+            "nexus.usecases.guardrails.project_guardrails_config.BedrockGuardrailPoolService.get_or_create_pool",
+            side_effect=_fake_pool_resolve,
+        )
+        self._mock_get_or_create_pool = self._pool_patcher.start()
+
+    def tearDown(self) -> None:
+        self._pool_patcher.stop()
 
     @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_lazy_init_new_project_blocks_all_categories(self):
@@ -133,6 +162,72 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
 
         self.assertEqual(updated.blocking_message, "Brand refusal")
         self.assertEqual(updated.category_states, config.category_states)
+        self._mock_get_or_create_pool.assert_not_called()
+
+    def test_update_category_assigns_pool_identifier_and_version(self):
+        project = ProjectFactory()
+        self.use_case.get_or_initialize(project)
+        ProjectGuardrailsConfig.objects.filter(project=project).update(
+            category_states=self.use_case.build_default_category_states(blocked=False),
+        )
+
+        config = self.use_case.update_config(project, category_states={"politics": True})
+
+        self.assertTrue(config.category_states["politics"])
+        self.assertIsNotNone(config.bedrock_guardrail_pool_id)
+        self.assertEqual(
+            config.bedrock_guardrail_identifier, config.bedrock_guardrail_pool.bedrock_guardrail_identifier
+        )
+        self.assertEqual(config.bedrock_guardrail_version, "1")
+        self._mock_get_or_create_pool.assert_called_once()
+
+    def test_update_all_unblocked_clears_pool_assignment(self):
+        project = ProjectFactory()
+        self.use_case.get_or_initialize(project)
+        ProjectGuardrailsConfig.objects.filter(project=project).update(
+            category_states=self.use_case.build_default_category_states(blocked=False),
+        )
+        assigned = self.use_case.update_config(project, category_states={"politics": True})
+        self.assertIsNotNone(assigned.bedrock_guardrail_pool_id)
+
+        cleared = self.use_case.update_config(
+            project,
+            category_states=self.use_case.build_default_category_states(blocked=False),
+        )
+
+        self.assertIsNone(cleared.bedrock_guardrail_pool_id)
+        self.assertIsNone(cleared.bedrock_guardrail_identifier)
+        self.assertIsNone(cleared.bedrock_guardrail_version)
+
+    def test_two_projects_with_same_subset_share_pool(self):
+        project_a = ProjectFactory()
+        project_b = ProjectFactory()
+        for project in (project_a, project_b):
+            self.use_case.get_or_initialize(project)
+            ProjectGuardrailsConfig.objects.filter(project=project).update(
+                category_states=self.use_case.build_default_category_states(blocked=False),
+            )
+
+        config_a = self.use_case.update_config(project_a, category_states={"politics": True, "bias": True})
+        config_b = self.use_case.update_config(project_b, category_states={"bias": True, "politics": True})
+
+        self.assertEqual(config_a.bedrock_guardrail_pool_id, config_b.bedrock_guardrail_pool_id)
+        self.assertEqual(config_a.bedrock_guardrail_identifier, config_b.bedrock_guardrail_identifier)
+
+    def test_update_category_propagates_bedrock_failure_without_saving(self):
+        project = ProjectFactory()
+        self.use_case.get_or_initialize(project)
+        ProjectGuardrailsConfig.objects.filter(project=project).update(
+            category_states=self.use_case.build_default_category_states(blocked=False),
+        )
+        self._mock_get_or_create_pool.side_effect = BedrockGuardrailPoolError("AccessDenied")
+
+        with self.assertRaises(BedrockGuardrailPoolError):
+            self.use_case.update_config(project, category_states={"politics": True})
+
+        config = ProjectGuardrailsConfig.objects.get(project=project)
+        self.assertFalse(config.category_states["politics"])
+        self.assertIsNone(config.bedrock_guardrail_pool_id)
 
 
 class GuardrailsConfigAdminPermissionTestCase(TestCase):


### PR DESCRIPTION
## Summary

- Wires category `PATCH` to `BedrockGuardrailPoolService.get_or_create_pool`, resolving before save so AWS failures leave local config unchanged
- Persists `bedrock_guardrail_pool` FK plus `identifier`/`version` on `ProjectGuardrailsConfig`; clears assignment when all categories are unblocked
- Message-only PATCH skips Bedrock pool resolution (FR-023); pool create/resolve errors surface as **502 Bad Gateway**
- Adds use case and API tests for pool assignment, shared pool reuse across projects, pool clearing, message-only skip, and Bedrock failure path (service mocked via `_fake_pool_resolve`)