### PR TITLE
fix: respect bedrock ingestion strategy in batch file upload

### DIFF
--- a/nexus/intelligences/api/test_batch_content_base_file.py
+++ b/nexus/intelligences/api/test_batch_content_base_file.py
@@ -101,13 +101,18 @@ class BatchContentBaseFileViewsetTestCase(TestCase):
         self.assertEqual(response.status_code, 201)
         content = response.json()
         self.assertEqual(len(content["files"]), 2)
+        mock_bedrock_cls.assert_called_with(
+            project_uuid=str(self.project.uuid),
+            force_direct_ingest=True,
+        )
         mock_batch_submit.assert_called_once()
         submitted_filenames = mock_batch_submit.call_args.args[2]
         self.assertEqual(submitted_filenames, ["file-a.txt", "file-b.txt"])
 
+    @patch("nexus.task_managers.file_manager.celery_file_manager.trigger_bedrock_ingestion.delay")
     @patch("nexus.task_managers.file_manager.celery_file_manager.direct_ingest_batch_submit.delay")
     @patch("nexus.task_managers.file_database.bedrock.BedrockFileDatabase")
-    def test_batch_create_accepts_job_strategy(self, mock_bedrock_cls, mock_batch_submit):
+    def test_batch_create_respects_job_strategy(self, mock_bedrock_cls, mock_batch_submit, mock_trigger_ingestion):
         self.project.bedrock_ingestion_strategy = Project.BEDROCK_INGESTION_JOB
         self.project.save(update_fields=["bedrock_ingestion_strategy"])
 
@@ -125,6 +130,8 @@ class BatchContentBaseFileViewsetTestCase(TestCase):
         self.assertEqual(response.status_code, 201)
         mock_bedrock_cls.assert_called_with(
             project_uuid=str(self.project.uuid),
-            force_direct_ingest=True,
+            force_direct_ingest=False,
         )
-        mock_batch_submit.assert_called_once()
+        mock_batch_submit.assert_not_called()
+        mock_trigger_ingestion.assert_called_once()
+        self.assertEqual(mock_trigger_ingestion.call_args.kwargs["project_uuid"], str(self.project.uuid))

--- a/nexus/task_managers/file_manager/celery_file_manager.py
+++ b/nexus/task_managers/file_manager/celery_file_manager.py
@@ -163,11 +163,15 @@ class CeleryFileManager:
         uploaded_files = []
         errors = []
 
+        project = None
+        project_uuid = None
         try:
             project = ProjectsUseCase().get_project_by_content_base_uuid(content_base_uuid)
             project_uuid = str(project.uuid)
         except Exception:
-            project_uuid = None
+            pass
+
+        use_direct_ingest = bool(project and project.bedrock_ingestion_strategy == Project.BEDROCK_INGESTION_DIRECT)
 
         for uploaded_file in files:
             filename = uploaded_file.name
@@ -178,7 +182,7 @@ class CeleryFileManager:
                 extension_file,
                 user_email,
                 project_uuid=project_uuid,
-                force_direct_ingest=True,
+                force_direct_ingest=use_direct_ingest,
             )
 
             if file_database_response.status != 0:
@@ -215,12 +219,19 @@ class CeleryFileManager:
         if not uploaded_files:
             return {"message": "No files were uploaded", "errors": errors}, http_status.HTTP_500_INTERNAL_SERVER_ERROR
 
-        direct_ingest_batch_submit.delay(
-            [item["task_manager_uuid"] for item in uploaded_files],
-            content_base_uuid,
-            [item["filename"] for item in uploaded_files],
-            project_uuid=project_uuid,
-        )
+        if use_direct_ingest:
+            direct_ingest_batch_submit.delay(
+                [item["task_manager_uuid"] for item in uploaded_files],
+                content_base_uuid,
+                [item["filename"] for item in uploaded_files],
+                project_uuid=project_uuid,
+            )
+        else:
+            for item in uploaded_files:
+                trigger_bedrock_ingestion.delay(
+                    item["task_manager_uuid"],
+                    project_uuid=project_uuid,
+                )
 
         response_data = {
             "files": [


### PR DESCRIPTION
## Changes

- Updated `upload_and_ingest_batch` to determine the ingestion method based on the project's `bedrock_ingestion_strategy`, passing `force_direct_ingest=False` when the strategy is not `BEDROCK_INGESTION_DIRECT`.
- When direct ingest is not used, `trigger_bedrock_ingestion.delay` is called per uploaded file instead of `direct_ingest_batch_submit.delay`.
- Fixed the test `test_batch_create_respects_job_strategy` to assert that `direct_ingest_batch_submit` is **not** called and that `trigger_bedrock_ingestion` is called with the correct `project_uuid` when the job strategy is active.
- Added an assertion in `test_batch_create_uploads_multiple_files` to verify that `BedrockFileDatabase` is instantiated with `force_direct_ingest=True` for the direct ingestion strategy.