### PR TITLE
fix: remove hardcoded region in `instruction_classify` and isolate inline traces region to validation

### DIFF
--- a/nexus/usecases/intelligences/lambda_usecase.py
+++ b/nexus/usecases/intelligences/lambda_usecase.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 
 class LambdaUseCase:
     def __init__(self, region: str = None):
-        region_name = (
-            region if region else settings.AWS_BEDROCK_INLINE_TRACES_REGION or settings.AWS_BEDROCK_REGION_NAME
-        )
+        region_name = region or settings.AWS_BEDROCK_REGION_NAME
         self.boto_client = boto3.client("lambda", region_name=region_name)
         self.adapter = None
         self.task_manager = None
@@ -583,8 +581,6 @@ class LambdaUseCase:
         language: str,
         project_description: str,
     ):
-        # hotfix, hardcoded region until usecase refactoring
-        lambda_usecase = LambdaUseCase("us-east-1")
         try:
             instructions_payload = {
                 "name": name,
@@ -598,7 +594,7 @@ class LambdaUseCase:
                 "project_description": project_description,
             }
 
-            response = lambda_usecase.invoke_lambda(
+            response = self.invoke_lambda(
                 lambda_name=str(settings.INSTRUCTION_CLASSIFY_NAME), payload=instructions_payload
             )
 

--- a/nexus/usecases/projects/ai_resolution_criteria.py
+++ b/nexus/usecases/projects/ai_resolution_criteria.py
@@ -51,7 +51,6 @@ class AIResolutionCriteriaUseCase:
             candidate_text=normalized_text,
             exclude_criterion_id=exclude_criterion_id,
         )
-        # Validation Lambda lives in AWS_BEDROCK_INLINE_TRACES_REGION (e.g. sa-east-1).
         validation_region = settings.AWS_BEDROCK_INLINE_TRACES_REGION or settings.AWS_BEDROCK_REGION_NAME
         lambda_result = LambdaUseCase(region=validation_region).validate_resolution_criterion(user_rules=user_rules)
 

--- a/nexus/usecases/projects/ai_resolution_criteria.py
+++ b/nexus/usecases/projects/ai_resolution_criteria.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.utils import timezone
@@ -50,7 +51,9 @@ class AIResolutionCriteriaUseCase:
             candidate_text=normalized_text,
             exclude_criterion_id=exclude_criterion_id,
         )
-        lambda_result = LambdaUseCase().validate_resolution_criterion(user_rules=user_rules)
+        # Validation Lambda lives in AWS_BEDROCK_INLINE_TRACES_REGION (e.g. sa-east-1).
+        validation_region = settings.AWS_BEDROCK_INLINE_TRACES_REGION or settings.AWS_BEDROCK_REGION_NAME
+        lambda_result = LambdaUseCase(region=validation_region).validate_resolution_criterion(user_rules=user_rules)
 
         if not lambda_result["valid"]:
             invalid_rules = [rule for rule in lambda_result.get("rules", []) if not rule.get("valid", True)]


### PR DESCRIPTION
## Changes

- Removed the hardcoded `us-east-1` region from `instruction_classify` and replaced the locally instantiated `LambdaUseCase` with `self.invoke_lambda`, using the existing instance's configuration.
- Simplified `LambdaUseCase.__init__` to resolve the region using `region or settings.AWS_BEDROCK_REGION_NAME`, removing the intermediate `AWS_BEDROCK_INLINE_TRACES_REGION` fallback from the constructor.
- Updated `AIResolutionCriteriaUseCase.validate_criterion` to explicitly resolve the region using `AWS_BEDROCK_INLINE_TRACES_REGION or AWS_BEDROCK_REGION_NAME` when instantiating `LambdaUseCase`, ensuring the correct region is used for resolution criterion validation.