### PR TITLE
fix: raise `AuthenticationFailed` on `ProjectAuthorizationDenied` in permissions

### DIFF
--- a/nexus/inline_agents/api/test_inline_agents_api.py
+++ b/nexus/inline_agents/api/test_inline_agents_api.py
@@ -411,6 +411,26 @@ class ProjectApiErrorMessageViewTestCase(TestCase):
         self.project.refresh_from_db()
         self.assertIsNone(self.project.api_error_message)
 
+    @mock.patch("nexus.projects.permissions._check_project_authorization")
+    def test_patch_returns_401_when_authorization_denied(self, mock_check_auth):
+        from nexus.projects.exceptions import ProjectAuthorizationDenied
+
+        mock_check_auth.side_effect = ProjectAuthorizationDenied("You do not have permission to perform this action.")
+
+        response = self.client.patch(
+            self.url,
+            {"error_message": "Should not be saved"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+        self.project.refresh_from_db()
+        self.assertIsNone(self.project.api_error_message)
+
 
 class ProjectActiveAgentsConfigViewTestCase(TestCase):
     def setUp(self):
@@ -429,8 +449,8 @@ class ProjectActiveAgentsConfigViewTestCase(TestCase):
         self.assertEqual(content, [])
 
     def test_get_returns_agent_config_with_tools(self):
-        from nexus.inline_agents.models import IntegratedAgent, Version
         from nexus.inline_agents.models import Agent as InlineAgent
+        from nexus.inline_agents.models import IntegratedAgent, Version
 
         agent = InlineAgent.objects.create(
             name="Agente de Troca e Devolução",
@@ -494,8 +514,8 @@ class ProjectActiveAgentsConfigViewTestCase(TestCase):
         self.assertEqual(param_names, {"order_id", "cpf"})
 
     def test_get_returns_empty_tools_when_agent_has_no_version(self):
-        from nexus.inline_agents.models import IntegratedAgent
         from nexus.inline_agents.models import Agent as InlineAgent
+        from nexus.inline_agents.models import IntegratedAgent
 
         agent = InlineAgent.objects.create(
             name="Agent Without Version",
@@ -516,8 +536,8 @@ class ProjectActiveAgentsConfigViewTestCase(TestCase):
         self.assertEqual(content[0]["tools"], [])
 
     def test_get_excludes_inactive_integrated_agents(self):
-        from nexus.inline_agents.models import IntegratedAgent, Version
         from nexus.inline_agents.models import Agent as InlineAgent
+        from nexus.inline_agents.models import IntegratedAgent, Version
 
         agent = InlineAgent.objects.create(
             name="Inactive Agent",

--- a/nexus/inline_agents/api/test_inline_agents_api.py
+++ b/nexus/inline_agents/api/test_inline_agents_api.py
@@ -412,7 +412,7 @@ class ProjectApiErrorMessageViewTestCase(TestCase):
         self.assertIsNone(self.project.api_error_message)
 
     @mock.patch("nexus.projects.permissions._check_project_authorization")
-    def test_patch_returns_401_when_authorization_denied(self, mock_check_auth):
+    def test_patch_returns_403_when_authorization_denied(self, mock_check_auth):
         from nexus.projects.exceptions import ProjectAuthorizationDenied
 
         mock_check_auth.side_effect = ProjectAuthorizationDenied("You do not have permission to perform this action.")
@@ -423,7 +423,7 @@ class ProjectApiErrorMessageViewTestCase(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},

--- a/nexus/projects/api/permissions.py
+++ b/nexus/projects/api/permissions.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from rest_framework import permissions
-from rest_framework.exceptions import AuthenticationFailed, ValidationError
+from rest_framework.exceptions import ValidationError
 
 from nexus.projects.exceptions import ProjectAuthorizationDenied
 from nexus.projects.models import ProjectAuth
@@ -28,8 +28,8 @@ class ProjectPermission(permissions.BasePermission):
             )
         except (ProjectAuth.DoesNotExist, StopIteration):
             return False
-        except ProjectAuthorizationDenied as e:
-            raise AuthenticationFailed(detail=e.detail) from e
+        except ProjectAuthorizationDenied:
+            raise
         except Exception as e:
             raise ValidationError({"detail": f"An error occurred: {str(e)}"}) from e
 

--- a/nexus/projects/api/permissions.py
+++ b/nexus/projects/api/permissions.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from rest_framework import permissions
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import AuthenticationFailed, ValidationError
 
+from nexus.projects.exceptions import ProjectAuthorizationDenied
 from nexus.projects.models import ProjectAuth
 from nexus.projects.permissions import has_external_general_project_permission
 
@@ -27,6 +28,8 @@ class ProjectPermission(permissions.BasePermission):
             )
         except (ProjectAuth.DoesNotExist, StopIteration):
             return False
+        except ProjectAuthorizationDenied as e:
+            raise AuthenticationFailed(detail=e.detail) from e
         except Exception as e:
             raise ValidationError({"detail": f"An error occurred: {str(e)}"}) from e
 


### PR DESCRIPTION
## Changes

- Implemented a new test to verify that a `403` status code is returned when `ProjectAuthorizationDenied` is raised during a `PATCH` request, ensuring the error message is not saved and the correct response detail is returned.
- Updated `ProjectPermission.has_permission` to explicitly catch `ProjectAuthorizationDenied` and re-raise it, returning a proper `403` response instead of falling through to the generic error handler.