### PR TITLE
feat: add hybrid JWT/Keycloak auth helpers for App IO endpoints

### DIFF
--- a/nexus/authentication/tests/test_weni_io.py
+++ b/nexus/authentication/tests/test_weni_io.py
@@ -1,0 +1,149 @@
+from unittest import mock
+from uuid import uuid4
+
+from django.test import SimpleTestCase
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.test import APIRequestFactory
+from weni_commons.auth import WeniAuthContext
+
+from nexus.authentication.weni_io import (
+    HybridIOInternalPermission,
+    HybridIOProjectPermission,
+    WeniIOAuthViewMixin,
+)
+
+
+class _DummyView(WeniIOAuthViewMixin):
+    kwargs = {}
+
+
+class HybridIOProjectPermissionTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = HybridIOProjectPermission()
+        self.view = mock.Mock()
+        self.view.kwargs = {"project_uuid": str(uuid4())}
+
+    def test_jwt_with_project_uuid_allows(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(
+            project_uuid=str(uuid4()),
+            user_email="io@example.com",
+            token_type="jwt",
+        )
+        self.assertTrue(self.permission.has_permission(request, self.view))
+
+    def test_jwt_without_project_uuid_denies(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(user_email="io@example.com", token_type="jwt")
+        self.assertFalse(self.permission.has_permission(request, self.view))
+
+    def test_jwt_with_only_vtex_account_denies(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(
+            vtex_account="mystore",
+            user_email="io@example.com",
+            token_type="jwt",
+        )
+        self.assertFalse(self.permission.has_permission(request, self.view))
+
+    @mock.patch("nexus.authentication.weni_io.ProjectPermission.has_permission", return_value=True)
+    @mock.patch(
+        "nexus.authentication.weni_io.CanCommunicateInternally.has_permission",
+        return_value=False,
+    )
+    def test_keycloak_falls_back_to_project_permission(self, _mock_internal, mock_project_permission):
+        request = self.factory.get("/")
+        request.user = mock.Mock(is_authenticated=True)
+        request.auth = WeniAuthContext(
+            project_uuid=str(uuid4()),
+            user_email="dash@example.com",
+            token_type="keycloak",
+        )
+        self.assertTrue(self.permission.has_permission(request, self.view))
+        mock_project_permission.assert_called_once()
+
+
+class HybridIOInternalPermissionTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = HybridIOInternalPermission()
+        self.view = mock.Mock()
+
+    def test_jwt_with_project_uuid_allows(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(
+            project_uuid=str(uuid4()),
+            user_email="io@example.com",
+            token_type="jwt",
+        )
+        self.assertTrue(self.permission.has_permission(request, self.view))
+
+    def test_jwt_with_only_vtex_account_denies(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(
+            vtex_account="mystore",
+            user_email="io@example.com",
+            token_type="jwt",
+        )
+        self.assertFalse(self.permission.has_permission(request, self.view))
+
+    @mock.patch(
+        "nexus.authentication.weni_io.CanCommunicateInternally.has_permission",
+        return_value=False,
+    )
+    @mock.patch(
+        "nexus.authentication.weni_io.ExternalTokenPermission.has_permission",
+        return_value=False,
+    )
+    def test_keycloak_without_internal_perm_denies(self, *_mocks):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(
+            project_uuid=str(uuid4()),
+            user_email="dash@example.com",
+            token_type="keycloak",
+        )
+        self.assertFalse(self.permission.has_permission(request, self.view))
+
+
+class WeniIOAuthViewMixinTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = _DummyView()
+        self.project_uuid = str(uuid4())
+
+    def test_uses_self_auth_project_uuid(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(project_uuid=self.project_uuid, token_type="jwt")
+        self.view.request = request
+        self.view.kwargs = {"project_uuid": self.project_uuid}
+        self.assertEqual(self.view.get_scoped_project_uuid(), self.project_uuid)
+
+    def test_mismatch_between_path_and_token_raises_403(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(project_uuid=self.project_uuid, token_type="jwt")
+        self.view.request = request
+        self.view.kwargs = {"project_uuid": str(uuid4())}
+        with self.assertRaises(PermissionDenied):
+            self.view.get_scoped_project_uuid()
+
+    def test_jwt_without_project_uuid_raises_403_without_path_fallback(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(vtex_account="mystore", token_type="jwt")
+        self.view.request = request
+        self.view.kwargs = {"project_uuid": self.project_uuid}
+        with self.assertRaises(PermissionDenied):
+            self.view.get_scoped_project_uuid()
+
+    def test_keycloak_uses_auth_project_uuid(self):
+        request = self.factory.get("/")
+        request.auth = WeniAuthContext(project_uuid=self.project_uuid, token_type="keycloak")
+        self.view.request = request
+        self.view.kwargs = {"project_uuid": self.project_uuid}
+        self.assertEqual(self.view.get_scoped_project_uuid(), self.project_uuid)
+
+    def test_falls_back_to_path_only_without_auth_context(self):
+        request = self.factory.get("/")
+        request.auth = None
+        self.view.request = request
+        self.assertEqual(self.view.get_scoped_project_uuid(self.project_uuid), self.project_uuid)

--- a/nexus/authentication/tests/test_weni_io.py
+++ b/nexus/authentication/tests/test_weni_io.py
@@ -4,17 +4,62 @@ from uuid import uuid4
 from django.test import SimpleTestCase
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.test import APIRequestFactory
-from weni_commons.auth import WeniAuthContext
+from weni_commons.auth import WeniAuthContext, WeniAuthUser
 
 from nexus.authentication.weni_io import (
     HybridIOInternalPermission,
     HybridIOProjectPermission,
     WeniIOAuthViewMixin,
+    resolve_django_user,
 )
+from nexus.users.models import User
 
 
 class _DummyView(WeniIOAuthViewMixin):
     kwargs = {}
+
+
+class ResolveDjangoUserTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    @mock.patch("nexus.authentication.weni_io.CreateUserUseCase")
+    def test_maps_weni_auth_user_to_django_user(self, mock_create_use_case):
+        django_user = mock.Mock(spec=User)
+        django_user.email = "io@example.com"
+        mock_create_use_case.return_value.create_user.return_value = django_user
+
+        request = self.factory.get("/")
+        request.user = WeniAuthUser(email="io@example.com")
+        request.auth = WeniAuthContext(
+            project_uuid=str(uuid4()),
+            user_email="io@example.com",
+            token_type="jwt",
+        )
+
+        user = resolve_django_user(request)
+
+        self.assertIs(user, django_user)
+        mock_create_use_case.return_value.create_user.assert_called_once_with("io@example.com")
+
+    def test_keeps_existing_django_user(self):
+        existing = User(email="dash@example.com")
+        request = self.factory.get("/")
+        request.user = existing
+        request.auth = WeniAuthContext(
+            project_uuid=str(uuid4()),
+            user_email="dash@example.com",
+            token_type="keycloak",
+        )
+
+        self.assertIs(resolve_django_user(request), existing)
+
+    def test_keeps_external_token_bool_user(self):
+        request = self.factory.get("/")
+        request.user = True
+        request.auth = None
+
+        self.assertIs(resolve_django_user(request), True)
 
 
 class HybridIOProjectPermissionTests(SimpleTestCase):

--- a/nexus/authentication/weni_io.py
+++ b/nexus/authentication/weni_io.py
@@ -1,6 +1,6 @@
 """Hybrid JWT/Keycloak auth helpers for App IO endpoints."""
 
-from typing import Optional
+from typing import Any, Optional
 
 from rest_framework import permissions
 from rest_framework.exceptions import PermissionDenied
@@ -9,11 +9,14 @@ from weni_commons.auth import (
     CanCommunicateInternally,
     WeniAuthContext,
     WeniAuthentication,
+    WeniAuthUser,
     WeniAuthViewMixin,
 )
 
 from nexus.authentication.authentication import ExternalTokenAuthentication
 from nexus.projects.api.permissions import ExternalTokenPermission, ProjectPermission
+from nexus.usecases.users.create import CreateUserUseCase
+from nexus.users.models import User
 
 
 class ExternalTokenAuthenticationWithHeader(ExternalTokenAuthentication):
@@ -24,6 +27,30 @@ class ExternalTokenAuthenticationWithHeader(ExternalTokenAuthentication):
 
 
 WENI_IO_AUTHENTICATION_CLASSES = [ExternalTokenAuthenticationWithHeader, WeniAuthentication]
+
+
+def resolve_django_user(request: Request) -> Any:
+    """Replace JWT ``WeniAuthUser`` with a persisted Django ``User``.
+
+    Nexus writes ``request.user`` into FKs (e.g. ``RecentActivities.created_by``).
+    ``WeniAuthentication`` returns a lightweight ``WeniAuthUser`` for App IO JWTs,
+    which is not a model instance — resolve by email via get_or_create.
+    Keycloak already yields a Django user; external tokens keep their bool user.
+    """
+    user = getattr(request, "user", None)
+    if isinstance(user, User):
+        return user
+
+    email = None
+    if isinstance(user, WeniAuthUser):
+        email = user.email
+    elif isinstance(getattr(request, "auth", None), WeniAuthContext):
+        email = request.auth.user_email
+
+    if email:
+        return CreateUserUseCase().create_user(email)
+
+    return user
 
 
 class HybridIOIdentityPermission(permissions.BasePermission):
@@ -98,6 +125,10 @@ class WeniIOAuthViewMixin(WeniAuthViewMixin):
 
     authentication_classes = WENI_IO_AUTHENTICATION_CLASSES
     permission_classes = [HybridIOIdentityPermission, HybridIOProjectPermission]
+
+    def perform_authentication(self, request: Request) -> None:
+        super().perform_authentication(request)
+        request.user = resolve_django_user(request)
 
     def get_scoped_project_uuid(self, path_project_uuid: Optional[str] = None) -> str:
         """Resolve project UUID for App IO hybrid auth.

--- a/nexus/authentication/weni_io.py
+++ b/nexus/authentication/weni_io.py
@@ -1,0 +1,126 @@
+"""Hybrid JWT/Keycloak auth helpers for App IO endpoints."""
+
+from typing import Optional
+
+from rest_framework import permissions
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from weni_commons.auth import (
+    CanCommunicateInternally,
+    WeniAuthContext,
+    WeniAuthentication,
+    WeniAuthViewMixin,
+)
+
+from nexus.authentication.authentication import ExternalTokenAuthentication
+from nexus.projects.api.permissions import ExternalTokenPermission, ProjectPermission
+
+
+class ExternalTokenAuthenticationWithHeader(ExternalTokenAuthentication):
+    """Preserve 401 WWW-Authenticate when this class is listed first."""
+
+    def authenticate_header(self, request):
+        return "Bearer"
+
+
+WENI_IO_AUTHENTICATION_CLASSES = [ExternalTokenAuthenticationWithHeader, WeniAuthentication]
+
+
+class HybridIOIdentityPermission(permissions.BasePermission):
+    """Require a Weni auth context, Django user, or external superuser token.
+
+    ExternalTokenAuthentication historically sets ``request.user`` to a bool,
+    so ``IsAuthenticated`` cannot be used directly.
+    """
+
+    def has_permission(self, request: Request, view) -> bool:
+        if isinstance(getattr(request, "auth", None), WeniAuthContext):
+            return True
+
+        if ExternalTokenPermission().has_permission(request, view):
+            return True
+
+        user = getattr(request, "user", None)
+        return bool(getattr(user, "is_authenticated", False)) if hasattr(user, "is_authenticated") else False
+
+
+class HybridIOProjectPermission(permissions.BasePermission):
+    """Authorize App IO routes under hybrid JWT + Keycloak auth.
+
+    - JWT: ``project_uuid`` claim is required (IO always sends it on these routes).
+    - Keycloak: keep existing project authorization checks.
+    - Legacy external/internal tokens remain allowed for compatibility.
+    """
+
+    def has_permission(self, request: Request, view) -> bool:
+        auth = request.auth
+        if isinstance(auth, WeniAuthContext) and auth.is_jwt:
+            return auth.has_project_uuid
+
+        if ExternalTokenPermission().has_permission(request, view):
+            return True
+
+        user = getattr(request, "user", None)
+        if not hasattr(user, "is_authenticated") or not user.is_authenticated:
+            return False
+
+        if CanCommunicateInternally().has_permission(request, view):
+            return True
+
+        return ProjectPermission().has_permission(request, view)
+
+
+class HybridIOInternalPermission(permissions.BasePermission):
+    """Like HybridIOProjectPermission, but Keycloak stays internal-only.
+
+    Used by commerce-router, which historically required
+    ``users.can_communicate_internally`` and should not open to every
+    project member via Keycloak.
+    """
+
+    def has_permission(self, request: Request, view) -> bool:
+        auth = request.auth
+        if isinstance(auth, WeniAuthContext) and auth.is_jwt:
+            return auth.has_project_uuid
+
+        if ExternalTokenPermission().has_permission(request, view):
+            return True
+
+        user = getattr(request, "user", None)
+        if not hasattr(user, "is_authenticated") or not user.is_authenticated:
+            return False
+
+        return CanCommunicateInternally().has_permission(request, view)
+
+
+class WeniIOAuthViewMixin(WeniAuthViewMixin):
+    """View mixin for Nexus routes consumed by the App IO."""
+
+    authentication_classes = WENI_IO_AUTHENTICATION_CLASSES
+    permission_classes = [HybridIOIdentityPermission, HybridIOProjectPermission]
+
+    def get_scoped_project_uuid(self, path_project_uuid: Optional[str] = None) -> str:
+        """Resolve project UUID for App IO hybrid auth.
+
+        - JWT / Keycloak (``WeniAuthContext``): read exclusively from
+          ``self.auth.project_uuid`` (403 when absent). Path may only match;
+          it never overrides the claim/resolved scope.
+        - External superuser token (no auth context): fall back to the path
+          for compatibility until those callers are migrated.
+        """
+        if path_project_uuid is None:
+            path_project_uuid = self.kwargs.get("project_uuid")
+
+        auth = getattr(self.request, "auth", None)
+        if isinstance(auth, WeniAuthContext):
+            # Prefer the mixin accessor so missing project_uuid raises 403
+            # the same way as Eliton's ``self.auth.project_uuid`` contract.
+            auth_project_uuid = str(self.auth.project_uuid)
+            if path_project_uuid and str(path_project_uuid) != auth_project_uuid:
+                raise PermissionDenied("Project UUID does not match authenticated scope.")
+            return auth_project_uuid
+
+        if path_project_uuid:
+            return str(path_project_uuid)
+
+        raise PermissionDenied("project_uuid could not be resolved from the request.")

--- a/nexus/inline_agents/api/views.py
+++ b/nexus/inline_agents/api/views.py
@@ -11,6 +11,7 @@ from rest_framework.views import APIView
 
 from inline_agents.backends import BackendsRegistry
 from nexus.authentication import AUTHENTICATION_CLASSES
+from nexus.authentication.weni_io import WeniIOAuthViewMixin
 from nexus.events import notify_async
 from nexus.inline_agents.api.mixins import OfficialAgentAssignmentMixin
 from nexus.inline_agents.api.serializers import (
@@ -48,8 +49,8 @@ from nexus.usecases.agents.exceptions import SkillFileTooLarge
 from nexus.usecases.inline_agents.assign import AssignAgentsUsecase
 from nexus.usecases.inline_agents.bedrock import (
     APM_INSTRUMENTATION_UNCHANGED,
-    APMNotConfiguredError,
     VALID_APM_INSTRUMENTATION,
+    APMNotConfiguredError,
 )
 from nexus.usecases.inline_agents.create import CreateAgentUseCase
 from nexus.usecases.inline_agents.get import GetInlineAgentsUsecase, GetInlineCredentialsUsecase, GetLogGroupUsecase
@@ -876,9 +877,7 @@ class ProjectActiveAgentsConfigView(APIView):
         },
     )
     def get(self, request, project_uuid):
-        integrated_agents = (
-            GetInlineAgentsUsecase().get_active_agents(project_uuid).prefetch_related("agent__versions")
-        )
+        integrated_agents = GetInlineAgentsUsecase().get_active_agents(project_uuid).prefetch_related("agent__versions")
         data = AgentConfigSerializer(integrated_agents, many=True).data
         return Response(data)
 
@@ -956,10 +955,9 @@ class ProjectCredentialsView(APIView):
         return Response({"message": "Credentials created successfully", "created_credentials": created_credentials})
 
 
-class ActivateAgentView(APIView):
-    permission_classes = [ProjectPermission | InternalCommunicationPermission]
-
+class ActivateAgentView(WeniIOAuthViewMixin, APIView):
     def patch(self, request, project_uuid, agent_uuid):
+        project_uuid = self.get_scoped_project_uuid(project_uuid)
         active = request.data.get("active")
         if not isinstance(active, bool):
             return Response(

--- a/nexus/intelligences/api/views.py
+++ b/nexus/intelligences/api/views.py
@@ -1793,14 +1793,12 @@ class UploadFileView(views.APIView):
         return Response({"file_url": file_url}, status=status.HTTP_201_CREATED)
 
 
-class CommerceHasAgentBuilder(views.APIView):
-    permission_classes = [InternalCommunicationPermission]
+class CommerceHasAgentBuilder(WeniIOAuthViewMixin, views.APIView):
+    permission_classes = [HybridIOIdentityPermission, HybridIOInternalPermission]
 
     def get(self, request):
-        project_uuid = request.query_params.get("project_uuid", None)
-
-        if not project_uuid:
-            return Response({"Error": "The project_uuid is required!"}, status=status.HTTP_400_BAD_REQUEST)
+        # project_uuid may arrive as query param (legacy) or from JWT/Keycloak auth context.
+        project_uuid = self.get_scoped_project_uuid(request.query_params.get("project_uuid"))
 
         content_base = get_default_content_base_by_project(project_uuid=project_uuid)
         agent = content_base.agent

--- a/nexus/intelligences/api/views.py
+++ b/nexus/intelligences/api/views.py
@@ -24,6 +24,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from nexus.agents.api.views import InternalCommunicationPermission
 from nexus.authentication import AUTHENTICATION_CLASSES
+from nexus.authentication.weni_io import HybridIOIdentityPermission, HybridIOInternalPermission, WeniIOAuthViewMixin
 from nexus.events import event_manager, notify_async
 from nexus.intelligences.api.filters import ConversationFilter
 from nexus.intelligences.models import (
@@ -39,7 +40,7 @@ from nexus.intelligences.models import (
 from nexus.internals.conversations import ConversationsRESTClient
 from nexus.orgs import permissions
 from nexus.paginations import CustomCursorPagination, InlineContentBaseTextCursorPagination, SupervisorPagination
-from nexus.projects.api.permissions import CombinedExternalProjectPermission, ExternalTokenPermission, ProjectPermission
+from nexus.projects.api.permissions import CombinedExternalProjectPermission, ProjectPermission
 from nexus.projects.exceptions import ProjectDoesNotExist
 from nexus.projects.models import Project
 from nexus.storage import AttachmentPreviewStorage, validate_mime_type
@@ -1495,25 +1496,27 @@ class RouterContentBaseViewSet(views.APIView):
         return Response(data=RouterContentBaseSerializer(content_base).data, status=200)
 
 
-class RouterRetailViewSet(views.APIView):
-    def _create_links(self, links: list, user: User, content_base: ContentBase, project: Project) -> list:
+class RouterRetailViewSet(WeniIOAuthViewMixin, views.APIView):
+    permission_classes = [HybridIOIdentityPermission, HybridIOInternalPermission]
+
+    def _create_links(self, links: list, user_email: str, content_base: ContentBase, project: Project) -> list:
         created_links = []
         if links:
             for link in links:
                 link_serializer = ContentBaseLinkSerializer(data={"link": link})
                 link_serializer.is_valid(raise_exception=True)
                 link_dto = intelligences.ContentBaseLinkDTO(
-                    link=link, user_email=user.email, content_base_uuid=str(content_base.uuid)
+                    link=link, user_email=user_email, content_base_uuid=str(content_base.uuid)
                 )
                 content_base_link = intelligences.CreateContentBaseLinkUseCase().create_content_base_link(link_dto)
 
                 if project.indexer_database == Project.BEDROCK:
                     bedrock_send_link.delay(
-                        link=link, user_email=user.email, content_base_link_uuid=str(content_base_link.uuid)
+                        link=link, user_email=user_email, content_base_link_uuid=str(content_base_link.uuid)
                     )
                 else:
                     send_link.delay(
-                        link=link, user_email=user.email, content_base_link_uuid=str(content_base_link.uuid)
+                        link=link, user_email=user_email, content_base_link_uuid=str(content_base_link.uuid)
                     )
 
                 link_serializer = CreatedContentBaseLinkSerializer(content_base_link).data
@@ -1521,19 +1524,19 @@ class RouterRetailViewSet(views.APIView):
 
     # TODO - Refactor this view to have only one searializer and no dependencies
     def post(self, request, project_uuid):
-        user: User = request.user
-        module_permission = user.has_perm("users.can_communicate_internally")
-
-        if not module_permission:
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
+        project_uuid = self.get_scoped_project_uuid(project_uuid)
+        user_email = self.user_email or getattr(request.user, "email", None)
+        is_internal = self.is_internal or (
+            hasattr(request.user, "has_perm") and request.user.has_perm("users.can_communicate_internally")
+        )
 
         use_case = intelligences.RetrieveContentBaseUseCase()
-        content_base = use_case.get_default_by_project(project_uuid, user.email, is_superuser=module_permission)
+        content_base = use_case.get_default_by_project(project_uuid, user_email, is_superuser=is_internal)
         links: list = request.data.get("links")
 
         project = ProjectsUseCase().get_project_by_content_base_uuid(content_base.uuid)
 
-        created_links = self._create_links(links, user, content_base, project)
+        created_links = self._create_links(links, user_email, content_base, project)
 
         # ContentBasePersonalization
 
@@ -1568,14 +1571,14 @@ class RouterRetailViewSet(views.APIView):
         return Response(response, status=200)
 
     def delete(self, request, project_uuid):
-        user: User = request.user
-        module_permission = user.has_perm("users.can_communicate_internally")
-
-        if not module_permission:
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
+        project_uuid = self.get_scoped_project_uuid(project_uuid)
+        user_email = self.user_email or getattr(request.user, "email", None)
+        is_internal = self.is_internal or (
+            hasattr(request.user, "has_perm") and request.user.has_perm("users.can_communicate_internally")
+        )
 
         use_case = intelligences.RetrieveContentBaseUseCase()
-        content_base = use_case.get_default_by_project(project_uuid, user.email, is_superuser=module_permission)
+        content_base = use_case.get_default_by_project(project_uuid, user_email, is_superuser=is_internal)
         content_base_uuid: str = content_base.uuid
 
         use_case = intelligences.RetrieveContentBaseLinkUseCase()
@@ -1602,6 +1605,10 @@ class RouterRetailViewSet(views.APIView):
                     content_base_uuid=str(content_base_uuid),
                     filename=filename,
                 )
+
+            user = request.user if hasattr(request.user, "pk") else None
+            if user is None and user_email:
+                user, _ = User.objects.get_or_create(email=user_email)
 
             event_manager.notify(event="contentbase_link_activity", action_type="D", content_base_link=link, user=user)
 
@@ -1672,10 +1679,8 @@ class LLMDefaultViewset(views.APIView):
         return Response(data=LLMConfigSerializer(updated_llm).data, status=200)
 
 
-class ContentBasePersonalizationViewSet(ModelViewSet):
+class ContentBasePersonalizationViewSet(WeniIOAuthViewMixin, ModelViewSet):
     serializer_class = ContentBasePersonalizationSerializer
-    authentication_classes = AUTHENTICATION_CLASSES
-    permission_classes = [ExternalTokenPermission | ProjectPermission | InternalCommunicationPermission]
 
     def get_queryset(self, *args, **kwargs):
         if getattr(self, "swagger_fake_view", False):
@@ -1686,7 +1691,7 @@ class ContentBasePersonalizationViewSet(ModelViewSet):
         return intelligences.get_default_content_base_by_project(project_uuid)
 
     def list(self, request, *args, **kwargs):
-        project_uuid = kwargs.get("project_uuid")
+        project_uuid = self.get_scoped_project_uuid(kwargs.get("project_uuid"))
         content_base = self._get_content_base(project_uuid)
         data = ContentBasePersonalizationSerializer(
             content_base, context={"request": request, "project_uuid": project_uuid}
@@ -1695,7 +1700,7 @@ class ContentBasePersonalizationViewSet(ModelViewSet):
 
     def update(self, request, *args, **kwargs):
         try:
-            project_uuid = kwargs.get("project_uuid")
+            project_uuid = self.get_scoped_project_uuid(kwargs.get("project_uuid"))
             content_base = self._get_content_base(project_uuid)
 
             context = {"request": request, "project_uuid": project_uuid}
@@ -1720,7 +1725,7 @@ class ContentBasePersonalizationViewSet(ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         instruction_id = request.query_params.get("id")
-        project_uuid = kwargs.get("project_uuid")
+        project_uuid = self.get_scoped_project_uuid(kwargs.get("project_uuid"))
         content_base = self._get_content_base(project_uuid)
 
         ids = [instruction_id]

--- a/nexus/intelligences/api/views.py
+++ b/nexus/intelligences/api/views.py
@@ -1729,6 +1729,9 @@ class ContentBasePersonalizationViewSet(WeniIOAuthViewMixin, ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         instruction_id = request.query_params.get("id")
+        if not instruction_id:
+            return Response({"error": "id is required"}, status=status.HTTP_400_BAD_REQUEST)
+
         project_uuid = self.get_scoped_project_uuid(kwargs.get("project_uuid"))
         content_base = self._get_content_base(project_uuid)
 

--- a/nexus/intelligences/api/views.py
+++ b/nexus/intelligences/api/views.py
@@ -1526,6 +1526,8 @@ class RouterRetailViewSet(WeniIOAuthViewMixin, views.APIView):
     def post(self, request, project_uuid):
         project_uuid = self.get_scoped_project_uuid(project_uuid)
         user_email = self.user_email or getattr(request.user, "email", None)
+        if not user_email:
+            return Response({"error": "user_email is required"}, status=status.HTTP_400_BAD_REQUEST)
         is_internal = self.is_internal or (
             hasattr(request.user, "has_perm") and request.user.has_perm("users.can_communicate_internally")
         )
@@ -1573,6 +1575,8 @@ class RouterRetailViewSet(WeniIOAuthViewMixin, views.APIView):
     def delete(self, request, project_uuid):
         project_uuid = self.get_scoped_project_uuid(project_uuid)
         user_email = self.user_email or getattr(request.user, "email", None)
+        if not user_email:
+            return Response({"error": "user_email is required"}, status=status.HTTP_400_BAD_REQUEST)
         is_internal = self.is_internal or (
             hasattr(request.user, "has_perm") and request.user.has_perm("users.can_communicate_internally")
         )

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -14,6 +14,7 @@ from rest_framework.views import APIView
 
 from inline_agents.backends.openai.backend import OpenAIBackend
 from nexus.agents.api.views import InternalCommunicationPermission
+from nexus.authentication.weni_io import WeniIOAuthViewMixin
 from nexus.events import notify_async
 from nexus.projects.api.permissions import ProjectPermission
 from nexus.projects.api.serializers import ConversationSerializer
@@ -197,9 +198,7 @@ class AgentBuilderProjectDetailsView(APIView):
         return Response(details)
 
 
-class ConversationsProxyView(APIView):
-    permission_classes = [IsAuthenticated, ProjectPermission | InternalCommunicationPermission]
-
+class ConversationsProxyView(WeniIOAuthViewMixin, APIView):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.usecase = ConversationsUsecase()
@@ -209,7 +208,7 @@ class ConversationsProxyView(APIView):
         Proxy endpoint to fetch conversations from Conversations service.
         All query parameters are forwarded directly to the Conversations service.
         """
-        project_uuid = kwargs.get("project_uuid")
+        project_uuid = self.get_scoped_project_uuid(kwargs.get("project_uuid"))
 
         if not project_uuid:
             return Response({"error": "project_uuid is required"}, status=status.HTTP_400_BAD_REQUEST)

--- a/nexus/projects/api/views.py
+++ b/nexus/projects/api/views.py
@@ -334,7 +334,17 @@ class ConversationsProxyView(WeniIOAuthViewMixin, APIView):
             status_code = getattr(e.response, "status_code", 500)
 
         if status_code == 404:
-            return Response({}, status=status.HTTP_200_OK)
+            return Response(
+                {
+                    "count": 0,
+                    "next": None,
+                    "previous": None,
+                    "results": [],
+                    "status_summary": None,
+                    "total_count": 0,
+                },
+                status=status.HTTP_200_OK,
+            )
 
         try:
             error_message, error_details = self.usecase.extract_error_message(e.response)

--- a/nexus/settings.py
+++ b/nexus/settings.py
@@ -651,7 +651,7 @@ PROGRESSIVE_FEEDBACK_ORCHESTRATION_INSTRUCTION = env.str(
 START_INLINE_AGENTS_ACK_LATE = env.bool("START_INLINE_AGENTS_ACK_LATE", False)
 ENABLE_LOGFIRE_OPENAI_AGENTS = env.bool("ENABLE_LOGFIRE_OPENAI_AGENTS", False)
 
-JWT_PUBLIC_KEY_PATH = BASE_DIR / "nexus" / "authentication" / "jwt_keys" / "public_key.pem"
+JWT_PUBLIC_KEY_PATH = BASE_DIR / "nexus" / "authentication" / "jwt_keys" / "public_key.perm"
 JWT_SECRET_KEY = env.str("JWT_SECRET_KEY")
 OPENAI_AGENTS_FOUNDATION_MODEL = env.str("OPENAI_AGENTS_FOUNDATION_MODEL", "gpt-4o-mini")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -8699,6 +8699,30 @@ files = [
 ]
 
 [[package]]
+name = "weni-commons"
+version = "1.3.2a7"
+description = "Weni's common utilities for Python backends"
+optional = false
+python-versions = "<4.0,>=3.8"
+groups = ["main"]
+files = [
+    {file = "weni_commons-1.3.2a7-py3-none-any.whl", hash = "sha256:17238333ac8a4a18daf0d02ce78b3b6b942adb0028ecea1be98665ba55d21d2b"},
+    {file = "weni_commons-1.3.2a7.tar.gz", hash = "sha256:386c8d02c78841e9000f5584a704414c8a5bdd0a9143c6275d76d8d7402145f3"},
+]
+
+[package.dependencies]
+boto3 = ">=1.18.0,<2.0.0"
+celery = ">=5.0.0,<6.0"
+django = ">=3.2.22,<6.0"
+django-redis = ">=4.0.0,<=6.0"
+djangorestframework = ">=3.12.0,<4.0"
+mozilla-django-oidc = ">=2.0.0,<5.0"
+pyjwt = ">=2.8.0,<3.0"
+requests = ">=2.25.0"
+weni-eda = ">=0.1.2,<0.3.0"
+weni-feature-flags = ">=2.2.0,<3.0.0"
+
+[[package]]
 name = "weni-datalake-sdk"
 version = "0.2.2"
 description = "Lib to connect python/django modules to redshift"
@@ -8719,20 +8743,36 @@ moto = ">=4.1,<5.0"
 pytest = ">=8.4.0,<9.0.0"
 
 [[package]]
+name = "weni-eda"
+version = "0.2.0"
+description = "Python library to simplify Event-Driven Architecture (EDA) with Django and RabbitMQ"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "weni_eda-0.2.0-py3-none-any.whl", hash = "sha256:a4a1b17f676d0da23205568beadba96fe054c2d7e4c1f5991af1a131850bf511"},
+    {file = "weni_eda-0.2.0.tar.gz", hash = "sha256:1aaf1f3398c3ab96edcf6dce978ecb7a02b1cbb91fec2247495d9d720723654e"},
+]
+
+[package.dependencies]
+amqp = ">=5.2.0,<6.0.0"
+
+[[package]]
 name = "weni-feature-flags"
-version = "2.1.2"
+version = "2.2.0"
 description = "Weni's feature flags SDK for Python backends"
 optional = false
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 files = [
-    {file = "weni_feature_flags-2.1.2-py3-none-any.whl", hash = "sha256:ce8ef0b8b0a78fa75c2399469b6deaeb4518cc4568b85111663080992536a3c4"},
-    {file = "weni_feature_flags-2.1.2.tar.gz", hash = "sha256:f38544ab5a8ec08d6257127769c2aa7dc64c709c75ffe613be82188aa29f7404"},
+    {file = "weni_feature_flags-2.2.0-py3-none-any.whl", hash = "sha256:a3d1898fa4992eca979261978d3db996973adff23a7cf98a75d5a22f73ba6b83"},
+    {file = "weni_feature_flags-2.2.0.tar.gz", hash = "sha256:145bfe816354bed204dd5efb4981cf1b4ec8df31d058740a669a8f400b8215d1"},
 ]
 
 [package.dependencies]
 celery = ">=5.0.0,<6.0"
 django = ">=3.2.22,<6.0"
+django-celery-beat = ">=2.5.0,<3.0"
 django-redis = ">=4.0.0,<=6.0"
 djangorestframework = ">=3.12.0,<4.0"
 growthbook = ">=1.0.0,<2.0"
@@ -9367,4 +9407,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "86aad17e46d40314053357f13afc036f3d46e2705458cc65dc29a433ba8e5150"
+content-hash = "f0ab6a1fc94f9391b0c47bf6fde22ad1839456cd00f8f8006b0312496fe62147"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"
 protobuf = ">=6.31,<7.0"
 weni-feature-flags = ">=2.1.0,<3.0.0"
+weni-commons = "1.3.2a7"
 
 
 


### PR DESCRIPTION
## Hybrid JWT/Keycloak Auth for App IO Endpoints

- Added `weni-commons==1.3.2a7` as a dependency to provide shared authentication utilities including `WeniAuthentication`, `WeniAuthContext`, and `WeniAuthViewMixin`.
- Introduced `nexus/authentication/weni_io.py` with `HybridIOIdentityPermission`, `HybridIOProjectPermission`, `HybridIOInternalPermission`, and `WeniIOAuthViewMixin` to support hybrid JWT and Keycloak authentication on App IO routes.
- `WeniIOAuthViewMixin.get_scoped_project_uuid()` resolves the project UUID exclusively from the JWT/Keycloak auth context, raising `PermissionDenied` on mismatches or missing claims, while falling back to the URL path only for legacy external token callers.
- `HybridIOInternalPermission` restricts Keycloak-authenticated requests to internal-only access (`can_communicate_internally`), preserving the existing security boundary for commerce-router routes.
- Migrated `ActivateAgentView`, `RouterRetailViewSet`, `ContentBasePersonalizationViewSet`, and `ConversationsProxyView` to use `WeniIOAuthViewMixin`, replacing the previous `ProjectPermission | InternalCommunicationPermission` and `ExternalTokenPermission` combinations.
- `RouterRetailViewSet.post` and `.delete` now derive `user_email` and `is_internal` from the auth context instead of directly from `request.user`, and resolve a `User` instance via `get_or_create` when needed for activity event logging.
- Added `ExternalTokenAuthenticationWithHeader` to preserve the `WWW-Authenticate: Bearer` header when the external token authenticator is listed first in `WENI_IO_AUTHENTICATION_CLASSES`.
- Added unit tests in `nexus/authentication/tests/test_weni_io.py` covering JWT allow/deny cases, Keycloak fallback behavior, and `get_scoped_project_uuid` mismatch and missing-claim scenarios.