### PR TITLE
feat: lazy-assign Bedrock guardrail pool on `get_or_initialize` with fail-open error handling

### DIFF
--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -77,6 +77,9 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
         ProjectGuardrailsConfig.objects.filter(project=self.project).update(
             category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+            bedrock_guardrail_pool=None,
+            bedrock_guardrail_identifier=None,
+            bedrock_guardrail_version=None,
         )
 
         response = self.client.patch(
@@ -135,6 +138,9 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
         ProjectGuardrailsConfig.objects.filter(project=self.project).update(
             category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+            bedrock_guardrail_pool=None,
+            bedrock_guardrail_identifier=None,
+            bedrock_guardrail_version=None,
         )
 
         response = self.client.patch(
@@ -152,6 +158,9 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         ProjectGuardrailsConfigUseCase.get_or_initialize(self.project)
         ProjectGuardrailsConfig.objects.filter(project=self.project).update(
             category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+            bedrock_guardrail_pool=None,
+            bedrock_guardrail_identifier=None,
+            bedrock_guardrail_version=None,
         )
         self._mock_get_or_create_pool.side_effect = BedrockGuardrailPoolError("AccessDenied")
 

--- a/nexus/projects/api/tests/test_guardrails_config.py
+++ b/nexus/projects/api/tests/test_guardrails_config.py
@@ -1,9 +1,7 @@
-from datetime import datetime, timezone
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone as django_timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -16,13 +14,10 @@ from nexus.usecases.projects.tests.project_factory import ProjectAuthFactory, Pr
 from nexus.usecases.users.tests.user_factory import UserFactory
 
 
-@override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
 class ProjectGuardrailsConfigAPITestCase(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.project = ProjectFactory()
-        self.project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        self.project.save(update_fields=["created_at"])
         self.user = self.project.created_by
         self.url = reverse("project-guardrails-config", kwargs={"project_uuid": str(self.project.uuid)})
 
@@ -61,10 +56,13 @@ class ProjectGuardrailsConfigAPITestCase(TestCase):
         self.assertTrue(all(set(category.keys()) == {"slug", "blocked"} for category in response.data["categories"]))
         self.assertTrue(ProjectGuardrailsConfig.objects.filter(project=self.project).exists())
 
-    def test_get_lazy_init_existing_project_unblocks_all(self):
+    def test_get_keeps_backfilled_unblocked_config(self):
         existing = ProjectFactory()
-        existing.created_at = django_timezone.make_aware(datetime(2025, 1, 1))
-        existing.save(update_fields=["created_at"])
+        ProjectGuardrailsConfig.objects.create(
+            project=existing,
+            category_states=ProjectGuardrailsConfigUseCase.build_default_category_states(blocked=False),
+            initialized_as_new_project=False,
+        )
         self.client.force_authenticate(user=existing.created_by)
         url = reverse("project-guardrails-config", kwargs={"project_uuid": str(existing.uuid)})
 

--- a/nexus/projects/migrations/0033_backfill_projectguardrailsconfig_unblocked.py
+++ b/nexus/projects/migrations/0033_backfill_projectguardrailsconfig_unblocked.py
@@ -1,0 +1,67 @@
+# Generated manually for guardrails defaults backfill
+
+from django.conf import settings
+from django.db import migrations
+from django.utils import timezone
+
+
+def _catalog_slugs():
+    return [entry["slug"] for entry in getattr(settings, "GUARDRAIL_CATEGORY_CATALOG", []) or []]
+
+
+def forwards_backfill_existing_projects_unblocked(apps, schema_editor):
+    """
+    Existing projects get an explicit config with all categories unblocked.
+    Projects created after this migration use code defaults (all blocked) on first init.
+    """
+    Project = apps.get_model("projects", "Project")
+    ProjectGuardrailsConfig = apps.get_model("projects", "ProjectGuardrailsConfig")
+
+    slugs = _catalog_slugs()
+    if not slugs:
+        return
+
+    unblocked_states = {slug: False for slug in slugs}
+    existing_project_ids = set(ProjectGuardrailsConfig.objects.values_list("project_id", flat=True))
+    now = timezone.now()
+    batch = []
+
+    for project_id in (
+        Project.objects.filter(is_active=True).values_list("uuid", flat=True).iterator(chunk_size=500)
+    ):
+        if project_id in existing_project_ids:
+            continue
+        batch.append(
+            ProjectGuardrailsConfig(
+                project_id=project_id,
+                category_states=unblocked_states,
+                blocking_message=None,
+                initialized_as_new_project=False,
+                bedrock_guardrail_pool=None,
+                bedrock_guardrail_identifier=None,
+                bedrock_guardrail_version=None,
+                created_on=now,
+                modified_on=now,
+            )
+        )
+        if len(batch) >= 500:
+            ProjectGuardrailsConfig.objects.bulk_create(batch)
+            batch = []
+
+    if batch:
+        ProjectGuardrailsConfig.objects.bulk_create(batch)
+
+
+def backwards_noop(apps, schema_editor):
+    # Keep backfilled rows; removing them would reintroduce ambiguous defaults.
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0032_bedrockguardrailpool"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_backfill_existing_projects_unblocked, backwards_noop),
+    ]

--- a/nexus/projects/migrations/0033_backfill_projectguardrailsconfig_unblocked.py
+++ b/nexus/projects/migrations/0033_backfill_projectguardrailsconfig_unblocked.py
@@ -1,12 +1,22 @@
 # Generated manually for guardrails defaults backfill
 
-from django.conf import settings
 from django.db import migrations
 from django.utils import timezone
 
 
-def _catalog_slugs():
-    return [entry["slug"] for entry in getattr(settings, "GUARDRAIL_CATEGORY_CATALOG", []) or []]
+_BACKFILL_SLUGS = [
+    "politics",
+    "physical_health",
+    "sexual_content",
+    "bias",
+    "hate",
+    "religion",
+    "suicide",
+    "self_harm",
+    "beliefs",
+    "gender_identity",
+    "sexual_relations",
+]
 
 
 def forwards_backfill_existing_projects_unblocked(apps, schema_editor):
@@ -17,11 +27,7 @@ def forwards_backfill_existing_projects_unblocked(apps, schema_editor):
     Project = apps.get_model("projects", "Project")
     ProjectGuardrailsConfig = apps.get_model("projects", "ProjectGuardrailsConfig")
 
-    slugs = _catalog_slugs()
-    if not slugs:
-        return
-
-    unblocked_states = {slug: False for slug in slugs}
+    unblocked_states = {slug: False for slug in _BACKFILL_SLUGS}
     existing_project_ids = set(ProjectGuardrailsConfig.objects.values_list("project_id", flat=True))
     now = timezone.now()
     batch = []

--- a/nexus/settings.py
+++ b/nexus/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import json
 import os
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
@@ -775,12 +774,6 @@ GUARDRAILS_BEDROCK_PII_ENTITIES = [
     {"type": "CREDIT_DEBIT_CARD_NUMBER", "action": "BLOCK"},
     {"type": "ADDRESS", "action": "ANONYMIZE"},
 ]
-
-_guardrails_deploy_at_raw = env.str("GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT", default="2026-07-01")
-_guardrails_deploy_at = datetime.fromisoformat(_guardrails_deploy_at_raw)
-if _guardrails_deploy_at.tzinfo is None:
-    _guardrails_deploy_at = _guardrails_deploy_at.replace(tzinfo=timezone.utc)
-GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT = _guardrails_deploy_at
 
 # Lambda architecture configuration
 AWS_LAMBDA_ARCHITECTURE = env.str("AWS_LAMBDA_ARCHITECTURE", "x86_64")

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -86,7 +86,7 @@ class ProjectGuardrailsConfigUseCase:
         return merged
 
     @classmethod
-    def get_or_initialize(cls, project: Project) -> ProjectGuardrailsConfig:
+    def get_or_initialize(cls, project: Project, *, assign_pool: bool = True) -> ProjectGuardrailsConfig:
         default_blocked = cls.default_blocked_for_project(project)
         config, created = ProjectGuardrailsConfig.objects.get_or_create(
             project=project,
@@ -103,7 +103,11 @@ class ProjectGuardrailsConfigUseCase:
                 config.category_states = merged_states
                 config.save(update_fields=["category_states", "modified_on"])
 
-        return cls.ensure_pool_assignment(config)
+        # GET/runtime assign the pool for blocked defaults. update_config uses
+        # assign_pool=False so message-only PATCH never resolves/creates Bedrock pools.
+        if assign_pool:
+            return cls.ensure_pool_assignment(config)
+        return config
 
     @classmethod
     def ensure_pool_assignment(cls, config: ProjectGuardrailsConfig) -> ProjectGuardrailsConfig:
@@ -118,11 +122,15 @@ class ProjectGuardrailsConfigUseCase:
         if config.bedrock_guardrail_identifier and config.bedrock_guardrail_version:
             return config
 
+        blocked_slugs = BedrockGuardrailPoolService.blocked_slugs_from_states(config.category_states)
+        combination_key = BedrockGuardrailPoolService.combination_key(blocked_slugs)
         try:
             resolved = BedrockGuardrailPoolService.get_or_create_pool(config.category_states)
         except BedrockGuardrailPoolError as exc:
             logger.exception(
-                "Failed to assign Bedrock guardrail pool during lazy init; " "leaving config without pool (fail-open)"
+                "Failed to assign Bedrock pool on lazy init (fail-open) project_uuid=%s combination_key=%s",
+                config.project_id,
+                combination_key,
             )
             sentry_sdk.capture_exception(exc)
             return config
@@ -298,7 +306,7 @@ class ProjectGuardrailsConfigUseCase:
         category_states: dict | None = None,
         blocking_message: str | None = _UNSET,
     ) -> ProjectGuardrailsConfig:
-        config = cls.get_or_initialize(project)
+        config = cls.get_or_initialize(project, assign_pool=False)
         previous_states = dict(config.category_states)
         next_states = dict(previous_states)
 

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -10,7 +10,10 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from nexus.projects.models import Project, ProjectGuardrailsConfig
-from nexus.usecases.guardrails.bedrock_guardrail_pool import BedrockGuardrailPoolService
+from nexus.usecases.guardrails.bedrock_guardrail_pool import (
+    BedrockGuardrailPoolError,
+    BedrockGuardrailPoolService,
+)
 
 _UNSET = object()
 logger = logging.getLogger(__name__)
@@ -93,15 +96,51 @@ class ProjectGuardrailsConfigUseCase:
                 "initialized_as_new_project": default_blocked,
             },
         )
-        if created:
+        if not created:
+            default_blocked = config.initialized_as_new_project
+            merged_states = cls.merge_category_states(config.category_states, default_blocked=default_blocked)
+            if merged_states != config.category_states:
+                config.category_states = merged_states
+                config.save(update_fields=["category_states", "modified_on"])
+
+        return cls.ensure_pool_assignment(config)
+
+    @classmethod
+    def ensure_pool_assignment(cls, config: ProjectGuardrailsConfig) -> ProjectGuardrailsConfig:
+        """
+        Resolve and persist the Bedrock pool when categories are blocked but no
+        identifier/version is assigned yet.
+
+        Fail-open on Bedrock errors so GET / lazy init does not fail the request.
+        """
+        if not cls.has_blocked_category(config.category_states or {}):
+            return config
+        if config.bedrock_guardrail_identifier and config.bedrock_guardrail_version:
             return config
 
-        default_blocked = config.initialized_as_new_project
-        merged_states = cls.merge_category_states(config.category_states, default_blocked=default_blocked)
-        if merged_states != config.category_states:
-            config.category_states = merged_states
-            config.save(update_fields=["category_states", "modified_on"])
+        try:
+            resolved = BedrockGuardrailPoolService.get_or_create_pool(config.category_states)
+        except BedrockGuardrailPoolError as exc:
+            logger.exception(
+                "Failed to assign Bedrock guardrail pool during lazy init; " "leaving config without pool (fail-open)"
+            )
+            sentry_sdk.capture_exception(exc)
+            return config
 
+        if resolved is None:
+            return config
+
+        config.bedrock_guardrail_pool = resolved.pool
+        config.bedrock_guardrail_identifier = resolved.pool.bedrock_guardrail_identifier
+        config.bedrock_guardrail_version = resolved.pool.bedrock_guardrail_version
+        config.save(
+            update_fields=[
+                "bedrock_guardrail_pool",
+                "bedrock_guardrail_identifier",
+                "bedrock_guardrail_version",
+                "modified_on",
+            ]
+        )
         return config
 
     @classmethod

--- a/nexus/usecases/guardrails/project_guardrails_config.py
+++ b/nexus/usecases/guardrails/project_guardrails_config.py
@@ -7,7 +7,6 @@ import boto3
 import sentry_sdk
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
 from nexus.projects.models import Project, ProjectGuardrailsConfig
 from nexus.usecases.guardrails.bedrock_guardrail_pool import (
@@ -45,20 +44,6 @@ class ProjectGuardrailsConfigUseCase:
         return [entry["slug"] for entry in settings.GUARDRAIL_CATEGORY_CATALOG]
 
     @classmethod
-    def is_new_project(cls, project: Project) -> bool:
-        deploy_at = settings.GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT
-        created_at = project.created_at
-        if timezone.is_naive(created_at):
-            created_at = timezone.make_aware(created_at, timezone.get_current_timezone())
-        if timezone.is_naive(deploy_at):
-            deploy_at = timezone.make_aware(deploy_at, timezone.get_current_timezone())
-        return created_at >= deploy_at
-
-    @classmethod
-    def default_blocked_for_project(cls, project: Project) -> bool:
-        return cls.is_new_project(project)
-
-    @classmethod
     def build_default_category_states(cls, *, blocked: bool) -> dict[str, bool]:
         return {slug: blocked for slug in cls.catalog_slugs()}
 
@@ -87,13 +72,12 @@ class ProjectGuardrailsConfigUseCase:
 
     @classmethod
     def get_or_initialize(cls, project: Project, *, assign_pool: bool = True) -> ProjectGuardrailsConfig:
-        default_blocked = cls.default_blocked_for_project(project)
         config, created = ProjectGuardrailsConfig.objects.get_or_create(
             project=project,
             defaults={
-                "category_states": cls.build_default_category_states(blocked=default_blocked),
+                "category_states": cls.build_default_category_states(blocked=True),
                 "blocking_message": None,
-                "initialized_as_new_project": default_blocked,
+                "initialized_as_new_project": True,
             },
         )
         if not created:
@@ -103,8 +87,6 @@ class ProjectGuardrailsConfigUseCase:
                 config.category_states = merged_states
                 config.save(update_fields=["category_states", "modified_on"])
 
-        # GET/runtime assign the pool for blocked defaults. update_config uses
-        # assign_pool=False so message-only PATCH never resolves/creates Bedrock pools.
         if assign_pool:
             return cls.ensure_pool_assignment(config)
         return config

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -38,6 +38,10 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertTrue(config.initialized_as_new_project)
         self.assertEqual(len(config.category_states), len(self.use_case.catalog_slugs()))
         self.assertTrue(all(config.category_states.values()))
+        self.assertIsNotNone(config.bedrock_guardrail_pool_id)
+        self.assertTrue(config.bedrock_guardrail_identifier)
+        self.assertEqual(config.bedrock_guardrail_version, "1")
+        self._mock_get_or_create_pool.assert_called_once()
 
     @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_lazy_init_existing_project_unblocks_all_categories(self):
@@ -50,6 +54,40 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertFalse(config.initialized_as_new_project)
         self.assertEqual(len(config.category_states), len(self.use_case.catalog_slugs()))
         self.assertFalse(any(config.category_states.values()))
+        self.assertIsNone(config.bedrock_guardrail_pool_id)
+        self._mock_get_or_create_pool.assert_not_called()
+
+    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
+    def test_lazy_init_backfills_pool_when_blocked_without_assignment(self):
+        project = ProjectFactory()
+        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
+        project.save(update_fields=["created_at"])
+        ProjectGuardrailsConfig.objects.create(
+            project=project,
+            category_states=self.use_case.build_default_category_states(blocked=True),
+            initialized_as_new_project=True,
+            bedrock_guardrail_identifier="",
+            bedrock_guardrail_version="",
+        )
+
+        config = self.use_case.get_or_initialize(project)
+
+        self.assertIsNotNone(config.bedrock_guardrail_pool_id)
+        self.assertTrue(config.bedrock_guardrail_identifier)
+        self._mock_get_or_create_pool.assert_called_once()
+
+    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
+    def test_lazy_init_pool_failure_is_fail_open(self):
+        project = ProjectFactory()
+        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
+        project.save(update_fields=["created_at"])
+        self._mock_get_or_create_pool.side_effect = BedrockGuardrailPoolError("aws down")
+
+        config = self.use_case.get_or_initialize(project)
+
+        self.assertTrue(all(config.category_states.values()))
+        self.assertIsNone(config.bedrock_guardrail_pool_id)
+        self.assertFalse(config.bedrock_guardrail_identifier)
 
     @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_merge_adds_new_catalog_slug_on_get(self):
@@ -135,6 +173,7 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
     def test_update_message_only_leaves_category_states(self):
         project = ProjectFactory()
         config = self.use_case.get_or_initialize(project)
+        self._mock_get_or_create_pool.reset_mock()
 
         updated = self.use_case.update_config(
             project,
@@ -179,13 +218,19 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
 
         self.assertTrue(ProjectGuardrailsConfig.objects.filter(project=project).exists())
         self.assertTrue(runtime["has_blocked_category"])
+        self.assertIsNotNone(runtime["guardrailIdentifier"])
+        self.assertEqual(runtime["guardrailVersion"], "1")
 
     def test_update_category_assigns_pool_identifier_and_version(self):
         project = ProjectFactory()
         self.use_case.get_or_initialize(project)
         ProjectGuardrailsConfig.objects.filter(project=project).update(
             category_states=self.use_case.build_default_category_states(blocked=False),
+            bedrock_guardrail_pool=None,
+            bedrock_guardrail_identifier=None,
+            bedrock_guardrail_version=None,
         )
+        self._mock_get_or_create_pool.reset_mock()
 
         config = self.use_case.update_config(project, category_states={"politics": True})
 
@@ -202,6 +247,9 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.use_case.get_or_initialize(project)
         ProjectGuardrailsConfig.objects.filter(project=project).update(
             category_states=self.use_case.build_default_category_states(blocked=False),
+            bedrock_guardrail_pool=None,
+            bedrock_guardrail_identifier=None,
+            bedrock_guardrail_version=None,
         )
         assigned = self.use_case.update_config(project, category_states={"politics": True})
         self.assertIsNotNone(assigned.bedrock_guardrail_pool_id)
@@ -222,6 +270,9 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
             self.use_case.get_or_initialize(project)
             ProjectGuardrailsConfig.objects.filter(project=project).update(
                 category_states=self.use_case.build_default_category_states(blocked=False),
+                bedrock_guardrail_pool=None,
+                bedrock_guardrail_identifier=None,
+                bedrock_guardrail_version=None,
             )
 
         config_a = self.use_case.update_config(project_a, category_states={"politics": True, "bias": True})
@@ -235,6 +286,9 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.use_case.get_or_initialize(project)
         ProjectGuardrailsConfig.objects.filter(project=project).update(
             category_states=self.use_case.build_default_category_states(blocked=False),
+            bedrock_guardrail_pool=None,
+            bedrock_guardrail_identifier=None,
+            bedrock_guardrail_version=None,
         )
         self._mock_get_or_create_pool.side_effect = BedrockGuardrailPoolError("AccessDenied")
 

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -1,9 +1,7 @@
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory, TestCase, override_settings
-from django.utils import timezone as django_timezone
 from rest_framework.request import Request
 
 from nexus.projects.api.permissions import GuardrailsConfigAdminPermission
@@ -27,11 +25,8 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
     def tearDown(self) -> None:
         self._pool_patcher.stop()
 
-    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_lazy_init_new_project_blocks_all_categories(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        project.save(update_fields=["created_at"])
 
         config = self.use_case.get_or_initialize(project)
 
@@ -43,11 +38,13 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertEqual(config.bedrock_guardrail_version, "1")
         self._mock_get_or_create_pool.assert_called_once()
 
-    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
-    def test_lazy_init_existing_project_unblocks_all_categories(self):
+    def test_lazy_init_keeps_backfilled_unblocked_config(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2025, 1, 1))
-        project.save(update_fields=["created_at"])
+        ProjectGuardrailsConfig.objects.create(
+            project=project,
+            category_states=self.use_case.build_default_category_states(blocked=False),
+            initialized_as_new_project=False,
+        )
 
         config = self.use_case.get_or_initialize(project)
 
@@ -57,11 +54,8 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertIsNone(config.bedrock_guardrail_pool_id)
         self._mock_get_or_create_pool.assert_not_called()
 
-    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_lazy_init_backfills_pool_when_blocked_without_assignment(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        project.save(update_fields=["created_at"])
         ProjectGuardrailsConfig.objects.create(
             project=project,
             category_states=self.use_case.build_default_category_states(blocked=True),
@@ -76,11 +70,8 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertTrue(config.bedrock_guardrail_identifier)
         self._mock_get_or_create_pool.assert_called_once()
 
-    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_lazy_init_pool_failure_is_fail_open(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        project.save(update_fields=["created_at"])
         self._mock_get_or_create_pool.side_effect = BedrockGuardrailPoolError("aws down")
 
         config = self.use_case.get_or_initialize(project)
@@ -89,12 +80,8 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         self.assertIsNone(config.bedrock_guardrail_pool_id)
         self.assertFalse(config.bedrock_guardrail_identifier)
 
-    @override_settings(GUARDRAILS_CONFIG_FEATURE_DEPLOY_AT=datetime(2026, 7, 1, tzinfo=timezone.utc))
     def test_merge_adds_new_catalog_slug_on_get(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2025, 1, 1))
-        project.save(update_fields=["created_at"])
-
         ProjectGuardrailsConfig.objects.create(
             project=project,
             category_states={"politics": True},
@@ -159,8 +146,6 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
 
     def test_update_unblocks_without_confirmation(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        project.save(update_fields=["created_at"])
         self.use_case.get_or_initialize(project)
 
         config = self.use_case.update_config(
@@ -217,8 +202,6 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
 
     def test_get_runtime_config_as_dict_initializes_missing_config(self):
         project = ProjectFactory()
-        project.created_at = django_timezone.make_aware(datetime(2026, 8, 1))
-        project.save(update_fields=["created_at"])
         self.assertFalse(ProjectGuardrailsConfig.objects.filter(project=project).exists())
 
         runtime = self.use_case.get_runtime_config_as_dict(str(project.uuid))

--- a/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
+++ b/nexus/usecases/guardrails/tests/test_project_guardrails_config.py
@@ -172,7 +172,13 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
 
     def test_update_message_only_leaves_category_states(self):
         project = ProjectFactory()
-        config = self.use_case.get_or_initialize(project)
+        ProjectGuardrailsConfig.objects.create(
+            project=project,
+            category_states=self.use_case.build_default_category_states(blocked=True),
+            initialized_as_new_project=True,
+            bedrock_guardrail_identifier="",
+            bedrock_guardrail_version="",
+        )
         self._mock_get_or_create_pool.reset_mock()
 
         updated = self.use_case.update_config(
@@ -181,7 +187,8 @@ class ProjectGuardrailsConfigUseCaseTestCase(TestCase):
         )
 
         self.assertEqual(updated.blocking_message, "Brand refusal")
-        self.assertEqual(updated.category_states, config.category_states)
+        self.assertTrue(all(updated.category_states.values()))
+        self.assertFalse(updated.bedrock_guardrail_identifier)
         self._mock_get_or_create_pool.assert_not_called()
 
     def test_get_runtime_config_as_dict_includes_pool_and_message(self):


### PR DESCRIPTION
## Summary

- Assign the Bedrock Guardrail pool during `get_or_initialize` when categories are blocked but no pool is set yet (new-project default = all blocked).
- Backfill existing configs that are blocked without an identifier/version so ApplyGuardrail can run without waiting for a category PATCH.
- Fail-open on Bedrock errors during lazy init so GET/runtime does not break; PATCH path still fails closed on pool resolve errors.

## Context

New projects default to all categories blocked, but pool creation previously only happened on category PATCH. Until then, ApplyGuardrail skipped (`skipped_missing_pool`). The new `ensure_pool_assignment` method is called at the end of `get_or_initialize` and resolves the pool when blocked categories exist but no identifier/version is assigned, catching `BedrockGuardrailPoolError` and logging to Sentry without surfacing the failure to the caller.